### PR TITLE
Fix missing error handling for two query.Exec() calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # turtle-cpm
 
 [![tests](https://github.com/vmiklos/turtle-cpm/workflows/tests/badge.svg)](https://github.com/vmiklos/turtle-cpm/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vmiklos/turtle-cpm)](https://goreportcard.com/report/github.com/vmiklos/turtle-cpm)
 
 The turtle console password manager is a replacement of the now gone
 <https://www.harry-b.de/dokuwiki/doku.php?id=harry:cpm>.

--- a/cpm.go
+++ b/cpm.go
@@ -72,10 +72,13 @@ func newUpdateCommand(db *sql.DB) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query, err := db.Prepare("update passwords set password=? where machine=? and service=? and user=? and type=?")
 			if err != nil {
-				return fmt.Errorf("db.Prepare(update) failed: %s", err)
+				return fmt.Errorf("db.Prepare() failed: %s", err)
 			}
 
 			_, err = query.Exec(password, machine, service, user, passwordType)
+			if err != nil {
+				return fmt.Errorf("db.Exec() failed: %s", err)
+			}
 
 			return nil
 		},
@@ -104,10 +107,13 @@ func newDeleteCommand(db *sql.DB) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			query, err := db.Prepare("delete from passwords where machine=? and service=? and user=? and type=?")
 			if err != nil {
-				return fmt.Errorf("db.Prepare(delete) failed: %s", err)
+				return fmt.Errorf("db.Prepare() failed: %s", err)
 			}
 
 			_, err = query.Exec(machine, service, user, passwordType)
+			if err != nil {
+				return fmt.Errorf("db.Exec() failed: %s", err)
+			}
 
 			return nil
 		},


### PR DESCRIPTION
As pointed out by
<https://goreportcard.com/report/github.com/vmiklos/turtle-cpm>.
