### PR TITLE
go-sqlite3 and cobra are not indirect dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/vmiklos/turtle-cpm
 go 1.16
 
 require (
-	github.com/mattn/go-sqlite3 v1.14.14 // indirect
-	github.com/spf13/cobra v1.5.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.14
+	github.com/spf13/cobra v1.5.0
 )


### PR DESCRIPTION
As `go mod tidy` points this out.
