### PR TITLE
Avoid hardcoded gpg uid

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Version descriptions
 
+## main
+
+- While encrypting the database, the `gpg` invocation now defaults to the self recipient, so no need
+  to specify a UID manually.
+
 ## 1.0
 
 - Initial release

--- a/cpm.go
+++ b/cpm.go
@@ -459,8 +459,7 @@ func closeDatabase(db *CpmDatabase) error {
 	}
 
 	os.Remove(db.PermanentPath)
-	// TODO harcoded uid
-	cmd := exec.Command("gpg", "--encrypt", "--sign", "-a", "-r", "03915096", "-o", db.PermanentPath, db.TempFile.Name())
+	cmd := exec.Command("gpg", "--encrypt", "--sign", "-a", "--default-recipient-self", "-o", db.PermanentPath, db.TempFile.Name())
 	err = cmd.Start()
 	if err != nil {
 		return fmt.Errorf("cmd.Start(gpg encrypt) failed: %s", err)


### PR DESCRIPTION
Turns out no need to have a config for this.
