### PR TITLE
Search: show totp shared secrets by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - While encrypting the database, the `gpg` invocation now defaults to the self recipient, so no need
   to specify a UID manually.
+- Search now shows both plain passwords and TOTP shared secrets by default, so in case a site only
+  has a TOTP shared secret, there is a search result instead of confusing empty output.
 
 ## 1.0
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![tests](https://github.com/vmiklos/turtle-cpm/workflows/tests/badge.svg)](https://github.com/vmiklos/turtle-cpm/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vmiklos/turtle-cpm)](https://goreportcard.com/report/github.com/vmiklos/turtle-cpm)
 
-The turtle console password manager is a replacement of the now gone
-<https://www.harry-b.de/dokuwiki/doku.php?id=harry:cpm>.
+The turtle console password manager is a replacement of the now gone [cpm
+project](https://www.harry-b.de/dokuwiki/doku.php?id=harry:cpm).
 
 ## Description
 
@@ -22,6 +22,5 @@ Notable features:
 
 ## The turtle
 
-turtle-cpm is turtle to be explicitly different from cpm, which is an independent from the original
-C codebase. It's turtle because this project is no longer implemented in C, so might be a little bit
-slower (though not significantly in practice).
+The turtle-cpm codebase is independent from the original cpm. It's turtle because this project is
+not in C, so might be a little bit slower (though not significantly in practice).

--- a/cpm.go
+++ b/cpm.go
@@ -353,7 +353,7 @@ func newReadCommand(db *sql.DB) *cobra.Command {
 	cmd.Flags().StringVarP(&machineFlag, "machine", "m", "", "machine (required)")
 	cmd.Flags().StringVarP(&serviceFlag, "service", "s", "", "service (required)")
 	cmd.Flags().StringVarP(&userFlag, "user", "u", "", "user (required)")
-	cmd.Flags().StringVarP(&typeFlag, "type", "t", "plain", "password type ('plain' or 'totp', default: plain)")
+	cmd.Flags().StringVarP(&typeFlag, "type", "t", "", "password type ('plain' or 'totp', default: '')")
 	cmd.Flags().BoolVarP(&totpFlag, "totp", "T", false, "show current TOTP, not the TOTP key (default: false, implies '--type totp')")
 
 	return cmd


### PR DESCRIPTION
To avoid confusion, it looked like data loss previously.
