### PR TITLE
Fold initDatabase() into openDatabase()

### DIFF
--- a/cpm_test.go
+++ b/cpm_test.go
@@ -26,6 +26,12 @@ func OpenDatabaseForTesting(sqlDb *sql.DB) func() (*CpmDatabase, error) {
 	return func() (*CpmDatabase, error) {
 		var db CpmDatabase
 		db.Database = sqlDb
+
+		err := initDatabase(db.Database)
+		if err != nil {
+			return nil, fmt.Errorf("initDatabase() failed: %s", err)
+		}
+
 		return &db, nil
 	}
 }


### PR DESCRIPTION
So the custom error handling (which is hard to test) can be avoided.

And similarly, split the DB shutdown into a close part (encrypt only on
success) and a clean part (always clean up decrypted data).
