### PR TITLE
Avoid github in go module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # turtle-cpm
 
 [![tests](https://github.com/vmiklos/turtle-cpm/workflows/tests/badge.svg)](https://github.com/vmiklos/turtle-cpm/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/vmiklos/turtle-cpm)](https://goreportcard.com/report/github.com/vmiklos/turtle-cpm)
+[![Go Report Card](https://goreportcard.com/badge/vmiklos.hu/go/turtle-cpm)](https://goreportcard.com/report/vmiklos.hu/go/turtle-cpm)
 
 The turtle console password manager handles your plain text passwords and your TOTP shared secrets.
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vmiklos/turtle-cpm
+module vmiklos.hu/go/turtle-cpm
 
 go 1.16
 

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -29,7 +29,7 @@ auto-generated passwords.
 You can install cpm using:
 
 ```sh
-go install github.com/vmiklos/turtle-cpm@latest
+go install vmiklos.hu/go/turtle-cpm@latest
 ```
 
 If you don't have the original cpm around, you can make a symlink to allow less typing:

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/vmiklos/turtle-cpm/commands"
+	"vmiklos.hu/go/turtle-cpm/commands"
 )
 
 func main() {

--- a/man/generate.go
+++ b/man/generate.go
@@ -4,7 +4,7 @@ import (
 	"log"
 
 	"github.com/spf13/cobra/doc"
-	"github.com/vmiklos/turtle-cpm/commands"
+	"vmiklos.hu/go/turtle-cpm/commands"
 )
 
 func main() {


### PR DESCRIPTION
See <https://gianarb.it/blog/go-mod-vanity-url> for motivation.
