### PR TITLE
import: avoid strange double removal

### DIFF
--- a/commands/commands_test.go
+++ b/commands/commands_test.go
@@ -450,8 +450,8 @@ func CommandForTesting(t *testing.T) func(name string, arg ...string) *exec.Cmd 
 				t.Fatalf("copyPath() failed: %s", err)
 			}
 			return exec.Command("true")
-		} else if len(arg) == 1 && name == "gunzip" {
-			compressedPath := arg[0]
+		} else if len(arg) == 2 && name == "gunzip" && arg[0] == "--force" {
+			compressedPath := arg[1]
 			uncompressedPath := strings.ReplaceAll(compressedPath, ".gz", "")
 			err := copyPath(compressedPath, uncompressedPath)
 			if err != nil {

--- a/commands/import.go
+++ b/commands/import.go
@@ -58,13 +58,13 @@ func newImportCommand(ctx *Context) *cobra.Command {
 
 			encryptedPath := usr.HomeDir + "/.cpmdb"
 			decryptedFile, err := ioutil.TempFile("", "cpm")
-			decryptedPath := decryptedFile.Name()
-			defer Remove(decryptedPath)
 			if err != nil {
 				return fmt.Errorf("ioutil.TempFile() failed: %s", err)
 			}
 
-			Remove(decryptedPath)
+			decryptedPath := decryptedFile.Name()
+			defer Remove(decryptedPath)
+
 			gpg := Command("gpg", "--decrypt", "-a", "-o", decryptedPath+".gz", encryptedPath)
 			err = gpg.Start()
 			if err != nil {
@@ -75,7 +75,7 @@ func newImportCommand(ctx *Context) *cobra.Command {
 				return fmt.Errorf("cmd.Wait() failed: %s", err)
 			}
 
-			gunzip := Command("gunzip", decryptedPath+".gz")
+			gunzip := Command("gunzip", "--force", decryptedPath+".gz")
 			err = gunzip.Start()
 			if err != nil {
 				return fmt.Errorf("cmd.Start(gunzip) failed: %s", err)


### PR DESCRIPTION
The first was to avoid interactive gunzip, the second is to not leave
decrypted data around. Eliminate the first by using force mode, so this
piece of code looks less odd.
