### PR TITLE
service: default to http

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## main
 
 - New password generation during update, the password flag is now optional.
+- The service flag is now optional in general, and defaults to "http".
 
 ## 3.0
 

--- a/commands/create.go
+++ b/commands/create.go
@@ -61,12 +61,11 @@ func newCreateCommand(ctx *Context) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&machine, "machine", "m", "", "machine (required)")
 	cmd.MarkFlagRequired("machine")
-	cmd.Flags().StringVarP(&service, "service", "s", "", "service (required)")
-	cmd.MarkFlagRequired("service")
+	cmd.Flags().StringVarP(&service, "service", "s", "http", "service")
 	cmd.Flags().StringVarP(&user, "user", "u", "", "user (required)")
 	cmd.MarkFlagRequired("user")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "password")
-	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", "password type ('plain' or 'totp', default: plain)")
+	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", `password type ("plain" or "totp")`)
 
 	return cmd
 }

--- a/commands/delete.go
+++ b/commands/delete.go
@@ -30,11 +30,10 @@ func newDeleteCommand(ctx *Context) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&machine, "machine", "m", "", "machine (required)")
 	cmd.MarkFlagRequired("machine")
-	cmd.Flags().StringVarP(&service, "service", "s", "", "service (required)")
-	cmd.MarkFlagRequired("service")
+	cmd.Flags().StringVarP(&service, "service", "s", "http", "service")
 	cmd.Flags().StringVarP(&user, "user", "u", "", "user (required)")
 	cmd.MarkFlagRequired("user")
-	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", "password type ('plain' or 'totp', default: plain)")
+	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", `password type ("plain" or "totp")`)
 
 	return cmd
 }

--- a/commands/read.go
+++ b/commands/read.go
@@ -106,11 +106,11 @@ func newReadCommand(ctx *Context) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&machineFlag, "machine", "m", "", "machine (required)")
-	cmd.Flags().StringVarP(&serviceFlag, "service", "s", "", "service (required)")
-	cmd.Flags().StringVarP(&userFlag, "user", "u", "", "user (required)")
-	cmd.Flags().StringVarP(&typeFlag, "type", "t", "", "password type ('plain' or 'totp', default: '')")
-	cmd.Flags().BoolVarP(&totpFlag, "totp", "T", false, "show current TOTP, not the TOTP key (default: false, implies '--type totp')")
+	cmd.Flags().StringVarP(&machineFlag, "machine", "m", "", `machine (default: "")`)
+	cmd.Flags().StringVarP(&serviceFlag, "service", "s", "", `service (default: "")`)
+	cmd.Flags().StringVarP(&userFlag, "user", "u", "", `user (default: "")`)
+	cmd.Flags().StringVarP(&typeFlag, "type", "t", "", `password type ('plain' or 'totp', default: "")`)
+	cmd.Flags().BoolVarP(&totpFlag, "totp", "T", false, `show current TOTP, not the TOTP key (default: false, implies "--type totp")`)
 	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "quite mode: only print the password itself (default: false)")
 
 	return cmd

--- a/commands/update.go
+++ b/commands/update.go
@@ -43,12 +43,11 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&machine, "machine", "m", "", "machine (required)")
 	cmd.MarkFlagRequired("machine")
-	cmd.Flags().StringVarP(&service, "service", "s", "", "service (required)")
-	cmd.MarkFlagRequired("service")
+	cmd.Flags().StringVarP(&service, "service", "s", "http", "service")
 	cmd.Flags().StringVarP(&user, "user", "u", "", "user (required)")
 	cmd.MarkFlagRequired("user")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "new password")
-	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", "password type ('plain' or 'totp', default: plain)")
+	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", `password type ("plain" or "totp")`)
 
 	return cmd
 }

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -8,20 +8,16 @@ most of the time, though.
 You can ask cpm to generate a password for you and remember it using:
 
 ```sh
-cpm create -m mymachine -s myservice -u myuser
+cpm create -m mymachine -u myuser
 ```
 
-Or in case you already have a preferred password:
+Or in case you already have non-HTTP service or a preferred password:
 
 ```sh
 cpm create -m mymachine -s myservice -u myuser -p mypassword
 ```
 
-A couple of useful conventions:
-
-- `mymachine` can be e.g. the domain of the website
-
-- `myserivce` can be e.g. just `http` if this is not some special protocol like LDAP or SSH
+When the machine is not yours, it can be e.g. the domain of a website.
 
 If you try to insert two passwords for the same machine/service/user combination, you will get an
 error. You can update or delete a password, though (see below).
@@ -50,7 +46,7 @@ TOTP is one from of Two-Factor Authentication (2FA), currently used by many popu
 shared secret and then add it to cpm using:
 
 ```sh
-cpm create -m mymachine -s myservice -u myuser -p "MY TOTP SHARED SECRET" -t totp
+cpm create -m mymachine -u myuser -p "MY TOTP SHARED SECRET" -t totp
 ```
 
 When searching, it's a good idea to first narrow down your search results to a single hit, e.g.
@@ -72,16 +68,22 @@ cpm --totp twitter
 Update is quite similar to creation. You can generate a new password using:
 
 ```sh
-cpm update -m mymachine -s myservice -u myuser
+cpm update -m mymachine -u myuser
 ```
 
-If you want to specify a new password explicitly, you can do that using:
+If you want to specify a service or a new password explicitly, you can do that using:
 
 ```sh
 cpm update -m mymachine -s myservice -u myuser -p mynewpassword
 ```
 
 Finally if you want to delete a password, you can do so by using:
+
+```sh
+cpm delete -m mymachine -u myuser
+```
+
+Or if you want to specify the service explicitly:
 
 ```sh
 cpm delete -m mymachine -s myservice -u myuser

--- a/man/cpm-create.1
+++ b/man/cpm-create.1
@@ -30,12 +30,12 @@ creates a new password
 	password
 
 .PP
-\fB-s\fP, \fB--service\fP=""
-	service (required)
+\fB-s\fP, \fB--service\fP="http"
+	service
 
 .PP
 \fB-t\fP, \fB--type\fP="plain"
-	password type ('plain' or 'totp', default: plain)
+	password type ("plain" or "totp")
 
 .PP
 \fB-u\fP, \fB--user\fP=""

--- a/man/cpm-delete.1
+++ b/man/cpm-delete.1
@@ -26,12 +26,12 @@ deletes an existing password
 	machine (required)
 
 .PP
-\fB-s\fP, \fB--service\fP=""
-	service (required)
+\fB-s\fP, \fB--service\fP="http"
+	service
 
 .PP
 \fB-t\fP, \fB--type\fP="plain"
-	password type ('plain' or 'totp', default: plain)
+	password type ("plain" or "totp")
 
 .PP
 \fB-u\fP, \fB--user\fP=""

--- a/man/cpm-search.1
+++ b/man/cpm-search.1
@@ -23,7 +23,7 @@ searches passwords
 
 .PP
 \fB-m\fP, \fB--machine\fP=""
-	machine (required)
+	machine (default: "")
 
 .PP
 \fB-q\fP, \fB--quiet\fP[=false]
@@ -31,19 +31,19 @@ searches passwords
 
 .PP
 \fB-s\fP, \fB--service\fP=""
-	service (required)
+	service (default: "")
 
 .PP
 \fB-T\fP, \fB--totp\fP[=false]
-	show current TOTP, not the TOTP key (default: false, implies '--type totp')
+	show current TOTP, not the TOTP key (default: false, implies "--type totp")
 
 .PP
 \fB-t\fP, \fB--type\fP=""
-	password type ('plain' or 'totp', default: '')
+	password type ('plain' or 'totp', default: "")
 
 .PP
 \fB-u\fP, \fB--user\fP=""
-	user (required)
+	user (default: "")
 
 
 .SH SEE ALSO

--- a/man/cpm-update.1
+++ b/man/cpm-update.1
@@ -30,12 +30,12 @@ updates an existing password
 	new password
 
 .PP
-\fB-s\fP, \fB--service\fP=""
-	service (required)
+\fB-s\fP, \fB--service\fP="http"
+	service
 
 .PP
 \fB-t\fP, \fB--type\fP="plain"
-	password type ('plain' or 'totp', default: plain)
+	password type ("plain" or "totp")
 
 .PP
 \fB-u\fP, \fB--user\fP=""


### PR DESCRIPTION
Password managers built into browsers only handle HTTP, cpm required to
state the service/protocol explicitly. Default to a middle ground where
HTTP is assumed, but other passwords are still possible to specify.

At least e.g. "ldap" for central passwords or "ssh" is what I still use
in my own db.
