### PR TITLE
Clean up duplicated Command() invocations

### DIFF
--- a/commands/import.go
+++ b/commands/import.go
@@ -65,24 +65,14 @@ func newImportCommand(ctx *Context) *cobra.Command {
 			decryptedPath := decryptedFile.Name()
 			defer Remove(decryptedPath)
 
-			gpg := Command("gpg", "--decrypt", "-a", "-o", decryptedPath+".gz", encryptedPath)
-			err = gpg.Start()
+			err = runCommand("gpg", "--decrypt", "-a", "-o", decryptedPath+".gz", encryptedPath)
 			if err != nil {
-				return fmt.Errorf("cmd.Start() failed: %s", err)
-			}
-			err = gpg.Wait()
-			if err != nil {
-				return fmt.Errorf("cmd.Wait() failed: %s", err)
+				return fmt.Errorf("runCommand() failed: %s", err)
 			}
 
-			gunzip := Command("gunzip", "--force", decryptedPath+".gz")
-			err = gunzip.Start()
+			err = runCommand("gunzip", "--force", decryptedPath+".gz")
 			if err != nil {
-				return fmt.Errorf("cmd.Start(gunzip) failed: %s", err)
-			}
-			err = gunzip.Wait()
-			if err != nil {
-				return fmt.Errorf("cmd.Wait(gunzip) failed: %s", err)
+				return fmt.Errorf("runCommand() failed: %s", err)
 			}
 
 			// Parse the XML.

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -17,12 +16,9 @@ func newSyncCommand(ctx *Context) *cobra.Command {
 				return fmt.Errorf("getDatabasePath() failed: %s", err)
 			}
 
-			command := Command("scp", "cpm:"+databasePath, databasePath)
-			command.Stdout = os.Stdout
-			command.Stderr = os.Stderr
-			err = command.Run()
+			err = runCommand("scp", "cpm:"+databasePath, databasePath)
 			if err != nil {
-				return fmt.Errorf("command.Run() failed: %s", err)
+				return fmt.Errorf("runCommand() failed: %s", err)
 			}
 
 			ctx.NoWriteBack = true


### PR DESCRIPTION
Now all interactive invocations go via runCommand() and that sets up
stdin/stdout/stderr properly in all cases.
