### PR TITLE
search: don't write back an unchanged database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ GO_OBJECTS = \
 	commands/root.go \
 	commands/root_test.go \
 	commands/sync.go \
+	commands/sync_test.go \
 	commands/update.go \
 	commands/update_test.go \
 	main.go \

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - `scripts/cpmsync.sh` is now a built-in subcommand, `cpm sync`. No need to install it manually
   anymore.
+- `cpm search` no longer encrypts the database at the end, to be a little bit faster.
 
 ## 4.0
 

--- a/commands/read.go
+++ b/commands/read.go
@@ -103,6 +103,7 @@ func newReadCommand(ctx *Context) *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", result)
 			}
 
+			ctx.NoWriteBack = true
 			return nil
 		},
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -120,9 +120,10 @@ func openDatabase(ctx *Context) error {
 	}
 	if pathExists(ctx.PermanentPath) {
 		Remove(ctx.TempFile.Name())
-		err := runCommand("gpg", "--decrypt", "-a", "-o", ctx.TempFile.Name(), ctx.PermanentPath)
+		command := Command("gpg", "--decrypt", "-a", "-o", ctx.TempFile.Name(), ctx.PermanentPath)
+		err = command.Run()
 		if err != nil {
-			return fmt.Errorf("runCommand() failed: %s", err)
+			return fmt.Errorf("Command() failed: %s", err)
 		}
 	}
 
@@ -168,9 +169,10 @@ func closeDatabase(ctx *Context) error {
 	}
 
 	Remove(ctx.PermanentPath)
-	err = runCommand("gpg", "--encrypt", "--sign", "-a", "--default-recipient-self", "-o", ctx.PermanentPath, ctx.TempFile.Name())
+	command := Command("gpg", "--encrypt", "--sign", "-a", "--default-recipient-self", "-o", ctx.PermanentPath, ctx.TempFile.Name())
+	err = command.Run()
 	if err != nil {
-		return fmt.Errorf("runCommand() failed: %s", err)
+		return fmt.Errorf("Command() failed: %s", err)
 	}
 
 	return nil


### PR DESCRIPTION
Avoids spawning a not needed gpg encrypt process.

Also switch back to non-interactive gpg till even 'gpg --quiet' shows
"info" output on decrypt.
