### PR TITLE
create: fail on invalid value of --type

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -17,7 +17,7 @@ func generatePassword() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-func createPassword(db *sql.DB, machine, service, user, password, passwordType string) (string, error) {
+func createPassword(db *sql.DB, machine, service, user, password string, passwordType PasswordType) (string, error) {
 	if len(password) == 0 {
 		var err error
 		password, err = generatePassword()
@@ -43,7 +43,7 @@ func newCreateCommand(ctx *Context) *cobra.Command {
 	var service string
 	var user string
 	var password string
-	var passwordType string
+	var passwordType PasswordType = "plain"
 	var cmd = &cobra.Command{
 		Use:   "create",
 		Short: "creates a new password",
@@ -65,7 +65,7 @@ func newCreateCommand(ctx *Context) *cobra.Command {
 	cmd.Flags().StringVarP(&user, "user", "u", "", "user (required)")
 	cmd.MarkFlagRequired("user")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "password")
-	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", `password type ("plain" or "totp")`)
+	cmd.Flags().VarP(&passwordType, "type", "t", `password type ("plain" or "totp")`)
 
 	return cmd
 }

--- a/commands/create_test.go
+++ b/commands/create_test.go
@@ -25,7 +25,7 @@ func TestInsert(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	expectedType := "plain"
-	os.Args = []string{"", "create", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser, "-p", expectedPassword}
+	os.Args = []string{"", "create", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser, "-p", expectedPassword, "-t", "plain"}
 	buf := new(bytes.Buffer)
 
 	actualRet := Main(buf)
@@ -187,5 +187,33 @@ func TestInsertFail(t *testing.T) {
 	actualOutput := buf.String()
 	if strings.HasPrefix(actualOutput, expectedPrefix) {
 		t.Fatalf("actualOutput = %q, want prefix %q", actualOutput, expectedPrefix)
+	}
+}
+
+// Insert fails because -t mytype is not a valid type.
+func TestInsertFailBadType(t *testing.T) {
+	db, err := CreateDatabaseForTesting()
+	defer db.Close()
+	if err != nil {
+		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
+	}
+	OldOpenDatabase := OpenDatabase
+	OpenDatabase = OpenDatabaseForTesting(db)
+	defer func() { OpenDatabase = OldOpenDatabase }()
+	OldCloseDatabase := CloseDatabase
+	CloseDatabase = CloseDatabaseForTesting
+	defer func() { CloseDatabase = OldCloseDatabase }()
+	expectedMachine := "mymachine"
+	expectedService := "myservice"
+	expectedUser := "myuser"
+	expectedPassword := "mypassword"
+	os.Args = []string{"", "create", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser, "-p", expectedPassword, "-t", "mytype"}
+	buf := new(bytes.Buffer)
+
+	actualRet := Main(buf)
+
+	expectedRet := 1
+	if actualRet != expectedRet {
+		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
 }

--- a/commands/delete_test.go
+++ b/commands/delete_test.go
@@ -22,7 +22,7 @@ func TestDelete(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
-	expectedType := "plain"
+	var expectedType PasswordType = "plain"
 	err = initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)

--- a/commands/import.go
+++ b/commands/import.go
@@ -105,7 +105,7 @@ func newImportCommand(ctx *Context) *cobra.Command {
 						userLabel := user.Label
 						for _, password := range user.Passwords {
 							passwordLabel := password.Label
-							var passwordType string
+							var passwordType PasswordType
 							if password.Totp == "true" {
 								passwordType = "totp"
 							} else {

--- a/commands/read_test.go
+++ b/commands/read_test.go
@@ -22,7 +22,7 @@ func TestSelect(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
-	expectedType := "plain"
+	var expectedType PasswordType = "plain"
 	err = initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
@@ -63,7 +63,7 @@ func TestQuietSelect(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
-	expectedType := "plain"
+	var expectedType PasswordType = "plain"
 	err = initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
@@ -107,7 +107,7 @@ func TestSelectTotpCode(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "totppassword"
-	expectedType := "totp"
+	var expectedType PasswordType = "totp"
 	err = initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)

--- a/commands/root.go
+++ b/commands/root.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -197,6 +198,36 @@ func runCommand(name string, arg ...string) error {
 	}
 
 	return nil
+}
+
+// PasswordType is an enum of possible password types.
+type PasswordType string
+
+const (
+	// PasswordTypePlain is a password sent to a server as-is.
+	PasswordTypePlain PasswordType = "plain"
+	// PasswordTypeTotp is a TOTP shared secret.
+	PasswordTypeTotp PasswordType = "totp"
+)
+
+func (t *PasswordType) String() string {
+	return string(*t)
+}
+
+// Set sets the value of `t` from `v`.
+func (t *PasswordType) Set(v string) error {
+	switch v {
+	case "plain", "totp":
+		*t = PasswordType(v)
+		return nil
+	default:
+		return errors.New(`must be one of "plain", or "totp"`)
+	}
+}
+
+// Type returns the type of `t` as a string.
+func (t *PasswordType) Type() string {
+	return "PasswordType"
 }
 
 // Main is the commandline interface to this package.

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -23,7 +23,7 @@ func TestUpdate(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "newpassword"
-	expectedType := "plain"
+	var expectedType PasswordType = "plain"
 	err = initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
@@ -80,7 +80,7 @@ func TestPwgenUpdate(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "output-from-pwgen"
-	expectedType := "plain"
+	var expectedType PasswordType = "plain"
 	err = initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)


### PR DESCRIPTION
Now we write:

	Error: invalid argument "mytype" for "-t, --type" flag: must be one of "plain", or "totp"

Instead of silently corrupting the database.
