### PR TITLE
update: fail on invalid value of --type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - `scripts/cpmsync.sh` is now a built-in subcommand, `cpm sync`. No need to install it manually
   anymore.
 - `cpm search` no longer encrypts the database at the end, to be a little bit faster.
+- create/search/update/delete's -t flag now has a proper type, so it errors on invalid values (other
+  than `plain` or `totp`)
 
 ## 4.0
 

--- a/commands/read.go
+++ b/commands/read.go
@@ -87,7 +87,8 @@ func newReadCommand(ctx *Context) *cobra.Command {
 	var machineFlag string
 	var serviceFlag string
 	var userFlag string
-	var typeFlag PasswordType = "plain"
+	// show all types by default
+	var typeFlag PasswordType
 	var totpFlag bool
 	var quietFlag bool
 	var cmd = &cobra.Command{

--- a/commands/update.go
+++ b/commands/update.go
@@ -11,7 +11,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	var service string
 	var user string
 	var password string
-	var passwordType string
+	var passwordType PasswordType = "plain"
 	var cmd = &cobra.Command{
 		Use:   "update",
 		Short: "updates an existing password",
@@ -47,7 +47,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	cmd.Flags().StringVarP(&user, "user", "u", "", "user (required)")
 	cmd.MarkFlagRequired("user")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "new password")
-	cmd.Flags().StringVarP(&passwordType, "type", "t", "plain", `password type ("plain" or "totp")`)
+	cmd.Flags().VarP(&passwordType, "type", "t", `password type ("plain" or "totp")`)
 
 	return cmd
 }


### PR DESCRIPTION
Now for real, since commit 36a7db7a11c632efa6c24ef3dc44692fd93d5d3d
(update: fail on invalid value of --type, 2022-08-05) make 'read' fail
instead.

Also fix read's default: continue to show both plain and totp items,
filtering for plain was not intentional.

If ever needed
<https://stackoverflow.com/questions/50824554/permitted-flag-values-for-cobra>
has some hints on bash completion, not done here.
