### PR TITLE
guide, usage: document -t param of search, update and delete

### DIFF
--- a/commands/read.go
+++ b/commands/read.go
@@ -111,7 +111,7 @@ func newReadCommand(ctx *Context) *cobra.Command {
 	cmd.Flags().StringVarP(&machineFlag, "machine", "m", "", `machine (default: "")`)
 	cmd.Flags().StringVarP(&serviceFlag, "service", "s", "", `service (default: "")`)
 	cmd.Flags().StringVarP(&userFlag, "user", "u", "", `user (default: "")`)
-	cmd.Flags().VarP(&typeFlag, "type", "t", `password type ("plain" or "totp")`)
+	cmd.Flags().VarP(&typeFlag, "type", "t", `password type ("plain" or "totp", default: "")`)
 	cmd.Flags().BoolVarP(&totpFlag, "totp", "T", false, `show current TOTP, not the TOTP key (default: false, implies "--type totp")`)
 	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "quite mode: only print the password itself (default: false)")
 

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -30,12 +30,12 @@ You can search in your passwords by entering a search term. You can do this impl
 cpm mymachine
 ```
 
-In the less likely case when you have multiple passwords on a website, you can be much more explicit
-and search using:
+In the less likely case when you have multiple passwords on a website or you want to hide TOTP
+shared secrets, you can be much more explicit and search using:
 
 
 ```sh
-cpm search -m mymachine -s myservice -u myuser
+cpm search -m mymachine -s myservice -u myuser -t plain
 ```
 
 ## TOTP support
@@ -71,10 +71,10 @@ Update is quite similar to creation. You can generate a new password using:
 cpm update -m mymachine -u myuser
 ```
 
-If you want to specify a service or a new password explicitly, you can do that using:
+If you want to specify a service, a type or a new password explicitly, you can do that using:
 
 ```sh
-cpm update -m mymachine -s myservice -u myuser -p mynewpassword
+cpm update -m mymachine -s myservice -u myuser -t plain -p mynewpassword
 ```
 
 Finally if you want to delete a password, you can do so by using:
@@ -83,8 +83,8 @@ Finally if you want to delete a password, you can do so by using:
 cpm delete -m mymachine -u myuser
 ```
 
-Or if you want to specify the service explicitly:
+Or if you want to specify the service or type explicitly:
 
 ```sh
-cpm delete -m mymachine -s myservice -u myuser
+cpm delete -m mymachine -s myservice -u myuser -t plain
 ```

--- a/man/cpm-create.1
+++ b/man/cpm-create.1
@@ -34,7 +34,7 @@ creates a new password
 	service
 
 .PP
-\fB-t\fP, \fB--type\fP="plain"
+\fB-t\fP, \fB--type\fP=plain
 	password type ("plain" or "totp")
 
 .PP

--- a/man/cpm-delete.1
+++ b/man/cpm-delete.1
@@ -30,7 +30,7 @@ deletes an existing password
 	service
 
 .PP
-\fB-t\fP, \fB--type\fP="plain"
+\fB-t\fP, \fB--type\fP=plain
 	password type ("plain" or "totp")
 
 .PP

--- a/man/cpm-search.1
+++ b/man/cpm-search.1
@@ -38,8 +38,8 @@ searches passwords
 	show current TOTP, not the TOTP key (default: false, implies "--type totp")
 
 .PP
-\fB-t\fP, \fB--type\fP=""
-	password type ('plain' or 'totp', default: "")
+\fB-t\fP, \fB--type\fP=
+	password type ("plain" or "totp", default: "")
 
 .PP
 \fB-u\fP, \fB--user\fP=""

--- a/man/cpm-update.1
+++ b/man/cpm-update.1
@@ -34,7 +34,7 @@ updates an existing password
 	service
 
 .PP
-\fB-t\fP, \fB--type\fP="plain"
+\fB-t\fP, \fB--type\fP=plain
 	password type ("plain" or "totp")
 
 .PP


### PR DESCRIPTION
Also restore the lost doc of search's --type default and update the
manpages.
