### PR TITLE
Rename the final executable name to just 'cpm'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # turtle-cpm
 
 [![tests](https://github.com/vmiklos/turtle-cpm/workflows/tests/badge.svg)](https://github.com/vmiklos/turtle-cpm/actions)
-[![Go Report Card](https://goreportcard.com/badge/vmiklos.hu/go/turtle-cpm)](https://goreportcard.com/report/vmiklos.hu/go/turtle-cpm)
+[![Go Report Card](https://goreportcard.com/badge/vmiklos.hu/go/cpm)](https://goreportcard.com/report/vmiklos.hu/go/cpm)
 
 The turtle console password manager handles your plain text passwords and your Time-based one-time
 password (TOTP) shared secrets.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module vmiklos.hu/go/turtle-cpm
+module vmiklos.hu/go/cpm
 
 go 1.16
 

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -29,11 +29,8 @@ auto-generated passwords.
 You can install cpm using:
 
 ```sh
-go install vmiklos.hu/go/turtle-cpm@latest
+go install vmiklos.hu/go/cpm@latest
 ```
 
-If you don't have the original cpm around, you can make a symlink to allow less typing:
-
-```sh
-ln -s $(go env GOPATH)/bin/turtle-cpm ~/bin/cpm
-```
+If `$(go env GOPATH)/bin` is not in your `PATH` yet, you may want to add it, so typing `cpm` will
+invoke the installed executable.

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"vmiklos.hu/go/turtle-cpm/commands"
+	"vmiklos.hu/go/cpm/commands"
 )
 
 func main() {

--- a/man/generate.go
+++ b/man/generate.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra/doc"
-	"vmiklos.hu/go/turtle-cpm/commands"
+	"vmiklos.hu/go/cpm/commands"
 )
 
 func main() {


### PR DESCRIPTION
It's unlikely that one want to spell out turtle-cpm all the time or have
a side-by-side install of the original cpm and this project.

`cpm --help` still says it explicitly that this is turtle-cpm.
