### PR TITLE
No need to host the release notes on GitHub

### DIFF
--- a/guide/src/README.md
+++ b/guide/src/README.md
@@ -3,8 +3,7 @@
 turtle-cpm is a command line tool to manage passwords, a replacement of the now gone [cpm
 project](https://www.harry-b.de/dokuwiki/doku.php?id=harry:cpm).
 
-The latest version is v4.0, released on 2022-08-03.  See the [release
-notes](https://github.com/vmiklos/turtle-cpm/blob/main/NEWS.md).
+The latest version is v4.0, released on 2022-08-03.  See the [release notes](news.md).
 
 Notable features:
 

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -7,3 +7,4 @@
 - [Installation](installation.md)
 - [Usage](usage.md)
 - [Advanced topics](advanced.md)
+- [Changelog](news.md)

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,4 +1,4 @@
-# Version descriptions
+# Changelog
 
 ## main
 


### PR DESCRIPTION
It's fine to have it as part of the self-hosted guide.
