### PR TITLE
search: add interactive mode

### DIFF
--- a/commands/read.go
+++ b/commands/read.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"bufio"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -95,6 +96,17 @@ func newReadCommand(ctx *Context) *cobra.Command {
 		Use:   "search",
 		Short: "searches passwords",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(machineFlag) == 0 && len(serviceFlag) == 0 && len(userFlag) == 0 && len(typeFlag) == 0 && len(args) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "Search term: ")
+				reader := bufio.NewReader(cmd.InOrStdin())
+				term, err := reader.ReadString('\n')
+				if err != nil {
+					return fmt.Errorf("ReadString() failed: %s", err)
+				}
+
+				args = append(args, strings.TrimSuffix(term, "\n"))
+			}
+
 			results, err := readPasswords(ctx.Database, machineFlag, serviceFlag, userFlag, typeFlag, totpFlag, quietFlag, args)
 			if err != nil {
 				return fmt.Errorf("readPasswords() failed: %s", err)

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -3,6 +3,7 @@
 ## main
 
 - create: add interactive mode in case `--machine` or `--user` is not specified
+- search: add interactive mode when no search terms are specified
 
 ## 5.0
 

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -34,15 +34,20 @@ an error. You can update or delete a password, though (see below).
 
 ## Reading
 
-You can search in your passwords by entering a search term. You can do this implicitly:
+You can search in your passwords by entering a search term. You can do this interactively:
 
 ```sh
-$ cpm example.com
+$ cpm
+Search term: example.com
 machine: example.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
 ```
 
-In the less likely case when you have multiple passwords on a website or you want to hide TOTP
-shared secrets, you can be much more explicit and search using:
+The search term can also be specified as an argument if non-interactive mode is wanted.
+
+Lastly, you can search your passwords by entering specifying search filters:
+
+- when you have multiple services or users on a machine
+- you want to hide TOTP shared secrets
 
 ```sh
 $ cpm search -m example.com -s http -u myuser -t plain


### PR DESCRIPTION
If there are no search filters or terms, ask for a term.

If you still want to list all passwords for some reason, "cpm -t plain"
and "cpm -t totp" will give you a full list.
