### PR TITLE
search: fix --help terminology

### DIFF
--- a/commands/read.go
+++ b/commands/read.go
@@ -124,7 +124,7 @@ func newReadCommand(ctx *Context) *cobra.Command {
 	cmd.Flags().StringVarP(&serviceFlag, "service", "s", "", `service (default: "")`)
 	cmd.Flags().StringVarP(&userFlag, "user", "u", "", `user (default: "")`)
 	cmd.Flags().VarP(&typeFlag, "type", "t", `password type ("plain" or "totp", default: "")`)
-	cmd.Flags().BoolVarP(&totpFlag, "totp", "T", false, `show current TOTP, not the TOTP key (default: false, implies "--type totp")`)
+	cmd.Flags().BoolVarP(&totpFlag, "totp", "T", false, `show the current TOTP code, not the TOTP shared secret (default: false, implies "--type totp")`)
 	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "quite mode: only print the password itself (default: false)")
 
 	return cmd

--- a/man/cpm-delete.1
+++ b/man/cpm-delete.1
@@ -23,7 +23,7 @@ deletes an existing password
 
 .PP
 \fB-m\fP, \fB--machine\fP=""
-	machine (required)
+	machine (default: ask)
 
 .PP
 \fB-s\fP, \fB--service\fP="http"
@@ -35,7 +35,7 @@ deletes an existing password
 
 .PP
 \fB-u\fP, \fB--user\fP=""
-	user (required)
+	user (default: ask)
 
 
 .SH SEE ALSO

--- a/man/cpm-search.1
+++ b/man/cpm-search.1
@@ -35,7 +35,7 @@ searches passwords
 
 .PP
 \fB-T\fP, \fB--totp\fP[=false]
-	show current TOTP, not the TOTP key (default: false, implies "--type totp")
+	show the current TOTP code, not the TOTP shared secret (default: false, implies "--type totp")
 
 .PP
 \fB-t\fP, \fB--type\fP=

--- a/man/cpm-update.1
+++ b/man/cpm-update.1
@@ -23,7 +23,7 @@ updates an existing password
 
 .PP
 \fB-m\fP, \fB--machine\fP=""
-	machine (required)
+	machine (default: ask)
 
 .PP
 \fB-p\fP, \fB--password\fP=""
@@ -39,7 +39,7 @@ updates an existing password
 
 .PP
 \fB-u\fP, \fB--user\fP=""
-	user (required)
+	user (default: ask)
 
 
 .SH SEE ALSO


### PR DESCRIPTION
"current TOTP" and "TOTP key" is not well-defined, "TOTP shared secret"
and "TOTP code" is, see <https://www.ietf.org/rfc/rfc6238.txt>.
