### PR TITLE
search, totp: handle URLs as TOTP shared secrets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
       - name: Run make check
         run: |
           tools/ci-build.sh

--- a/commands/read_test.go
+++ b/commands/read_test.go
@@ -436,3 +436,26 @@ func TestOpenCloseDatabase(t *testing.T) {
 	}
 	os.Remove("qa/passwords.db")
 }
+
+func TestParsePassword(t *testing.T) {
+	s := "otpauth://totp/Myserver:myuser?secret=mysecret&digits=6&algorithm=SHA1&issuer=Myserver&period=30"
+	expected := "mysecret"
+
+	actual, err := parsePassword(s)
+	if err != nil {
+		t.Fatalf("err = %q, want nil", err)
+	}
+
+	if actual != expected {
+		t.Fatalf("actual = %q, want %q", actual, expected)
+	}
+}
+
+func TestParsePasswordBadURL(t *testing.T) {
+	s := "otpauth://totp/Myserver:myuser?digits=6&algorithm=SHA1&issuer=Myserver&period=30"
+
+	_, err := parsePassword(s)
+	if err == nil {
+		t.Fatalf("err = nil, want !nil")
+	}
+}

--- a/guide/src/advanced.md
+++ b/guide/src/advanced.md
@@ -79,3 +79,18 @@ cpm create -h
 ```
 
 An alternative to this is the manual pages under `man/`, which provide the same information.
+
+## Re-sharing TOTP shared secrets
+
+TOTP shared secrets are typically transfered as QR codes, though there is usually a fallback option
+to get the shared secret string itself, which is what `cpm` can manage. However, the QR code also
+contains other information about the shared secret, and there are tools like
+[2fa-qr](https://stefansundin.github.io/2fa-qr/) that allow obtaining the full `otpauth://` URL from the
+QR code image. `cpm` supports storing these full URLs as well, they look something like this:
+
+otpauth://totp/Myserver:myuser?secret=...&digits=6&algorithm=SHA1&issuer=Myserver&period=30
+
+Where Myserver is some server-side app name and myuser is your user name.
+
+The benefit of storing the full URL in the `cpm` database is that later you can re-share them as QR
+codes, e.g. with `2fa-qr`.

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+- when specifying TOTP shared secrets, it is now supported to specify `otpauth://` URLs
+
 ## 7.0
 
 - new `version` subcommand that shows the version number


### PR DESCRIPTION
i.e. allow not only the shared secret itself in base64 form, but a full
URL from a qrcode.
