### PR TITLE
Respect a custom XDG_STATE_HOME env var

### DIFF
--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -140,3 +140,20 @@ func CopyPath(inPath, outPath string) error {
 
 	return nil
 }
+
+// TestGetDatabasePath checks if getDatabasePath() handles a custom XDG_STATE_HOME value.
+func TestGetDatabasePath(t *testing.T) {
+	oldEnv := os.Getenv(xdgStateHome)
+	os.Setenv(xdgStateHome, "/tmp")
+	defer func() { os.Setenv(xdgStateHome, oldEnv) }()
+
+	actual, err := getDatabasePath()
+	if err != nil {
+		t.Fatalf("getDatabasePath() err = %q, want nil", err)
+	}
+
+	expected := "/tmp/cpm/passwords.db"
+	if actual != expected {
+		t.Fatalf("getDatabasePath() = %q, want %q", actual, expected)
+	}
+}

--- a/guide/src/advanced.md
+++ b/guide/src/advanced.md
@@ -49,7 +49,7 @@ cpm import
 ## Inspecting the encrypted database manually
 
 In case you want to inspect the SQLite database of `cpm` manually, you need to decrypt it yourself,
-using:
+using (assuming an empty `XDG_STATE_HOME` environment variable):
 
 ```sh
 gpg --decrypt -a -o decrypted.db ~/.local/state/cpm/passwords.db

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+- in case the `XDG_STATE_HOME` environment variable is set to a custom value, it is now respected
+
 ## 7.1
 
 - when specifying TOTP shared secrets, it is now supported to specify `otpauth://` URLs


### PR DESCRIPTION
The database path continues to default to
`~/.local/state/cpm/passwords.db`.
