### PR TITLE
test: introduce UseDatabaseForTesting() to avoid duplication

### DIFF
--- a/commands/create_test.go
+++ b/commands/create_test.go
@@ -14,9 +14,7 @@ func TestInsert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -61,9 +59,7 @@ func TestNoServiceInsert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -107,9 +103,7 @@ func TestPwgenInsert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -158,9 +152,7 @@ func TestInsertFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -201,9 +193,7 @@ func TestInsertFailBadType(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -229,9 +219,7 @@ func TestInteractiveInsert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()

--- a/commands/delete_test.go
+++ b/commands/delete_test.go
@@ -12,9 +12,7 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -58,9 +56,7 @@ func TestInteractiveDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -13,9 +13,7 @@ func TestImport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()

--- a/commands/read_test.go
+++ b/commands/read_test.go
@@ -15,9 +15,7 @@ func TestSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -57,9 +55,7 @@ func TestQuietSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -99,9 +95,7 @@ func TestSelectTotpCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -148,9 +142,7 @@ func TestQrcodeSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -194,9 +186,7 @@ func TestSelectMachineFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -236,9 +226,7 @@ func TestSelectServiceFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -278,9 +266,7 @@ func TestSelectUserFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -320,9 +306,7 @@ func TestSelectTypeFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -362,9 +346,7 @@ func TestSelectImplicitFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -405,9 +387,7 @@ func TestSelectInteractive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -141,6 +141,12 @@ func CopyPath(inPath, outPath string) error {
 	return nil
 }
 
+func UseDatabaseForTesting(t *testing.T, db *sql.DB) {
+	oldOpenDatabase := OpenDatabase
+	OpenDatabase = OpenDatabaseForTesting(db)
+	t.Cleanup(func() { OpenDatabase = oldOpenDatabase })
+}
+
 // TestGetDatabasePath checks if getDatabasePath() handles a custom XDG_STATE_HOME value.
 func TestGetDatabasePath(t *testing.T) {
 	oldEnv := os.Getenv(xdgStateHome)

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -13,9 +13,7 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -68,9 +66,7 @@ func TestPwgenUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()
@@ -126,9 +122,7 @@ func TestInteractiveUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
 	}
-	OldOpenDatabase := OpenDatabase
-	OpenDatabase = OpenDatabaseForTesting(db)
-	defer func() { OpenDatabase = OldOpenDatabase }()
+	UseDatabaseForTesting(t, db)
 	OldCloseDatabase := CloseDatabase
 	CloseDatabase = CloseDatabaseForTesting
 	defer func() { CloseDatabase = OldCloseDatabase }()


### PR DESCRIPTION
This was mostly duplicated because I wasn't aware of
testing.T.Cleanup().
