### PR TITLE
CreateDatabaseForTesting: ensure the db is closed

### DIFF
--- a/commands/create_test.go
+++ b/commands/create_test.go
@@ -9,11 +9,7 @@ import (
 )
 
 func TestInsert(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
@@ -51,11 +47,7 @@ func TestInsert(t *testing.T) {
 }
 
 func TestNoServiceInsert(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedUser := "myuser"
@@ -92,11 +84,7 @@ func TestNoServiceInsert(t *testing.T) {
 }
 
 func TestPwgenInsert(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseCommandForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
@@ -136,11 +124,7 @@ func TestPwgenInsert(t *testing.T) {
 
 // Insert fails because the password is already inserted.
 func TestInsertFail(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
@@ -174,11 +158,7 @@ func TestInsertFail(t *testing.T) {
 
 // Insert fails because -t mytype is not a valid type.
 func TestInsertFailBadType(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
@@ -197,11 +177,7 @@ func TestInsertFailBadType(t *testing.T) {
 }
 
 func TestInteractiveInsert(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"

--- a/commands/delete_test.go
+++ b/commands/delete_test.go
@@ -7,18 +7,14 @@ import (
 )
 
 func TestDelete(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -48,18 +44,14 @@ func TestDelete(t *testing.T) {
 }
 
 func TestInteractiveDelete(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -8,11 +8,7 @@ import (
 )
 
 func TestImport(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseCommandForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"

--- a/commands/read_test.go
+++ b/commands/read_test.go
@@ -10,18 +10,14 @@ import (
 )
 
 func TestSelect(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -47,18 +43,14 @@ func TestSelect(t *testing.T) {
 }
 
 func TestQuietSelect(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -84,11 +76,7 @@ func TestQuietSelect(t *testing.T) {
 }
 
 func TestSelectTotpCode(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseCommandForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
@@ -96,7 +84,7 @@ func TestSelectTotpCode(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "totppassword"
 	var expectedType PasswordType = "totp"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -126,11 +114,7 @@ func GenerateQrCodeForTesting(text string, l qr.Level, w io.Writer) {
 }
 
 func TestQrcodeSelect(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	OldGenerateQrCode := GenerateQrCode
 	GenerateQrCode = GenerateQrCodeForTesting
@@ -140,7 +124,7 @@ func TestQrcodeSelect(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "totp"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -167,13 +151,9 @@ func TestQrcodeSelect(t *testing.T) {
 }
 
 func TestSelectMachineFilter(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -204,13 +184,9 @@ func TestSelectMachineFilter(t *testing.T) {
 }
 
 func TestSelectServiceFilter(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -241,13 +217,9 @@ func TestSelectServiceFilter(t *testing.T) {
 }
 
 func TestSelectUserFilter(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -278,13 +250,9 @@ func TestSelectUserFilter(t *testing.T) {
 }
 
 func TestSelectTypeFilter(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -315,13 +283,9 @@ func TestSelectTypeFilter(t *testing.T) {
 }
 
 func TestSelectImplicitFilter(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -353,13 +317,9 @@ func TestSelectImplicitFilter(t *testing.T) {
 }
 
 func TestSelectInteractive(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -11,13 +11,14 @@ import (
 )
 
 // CreateDatabaseForTesting creates an in-memory database.
-func CreateDatabaseForTesting() (*sql.DB, error) {
+func CreateDatabaseForTesting(t *testing.T) *sql.DB {
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
-		return nil, fmt.Errorf("sql.Open() failed: %s", err)
+		t.Fatalf("sql.Open() failed: %s", err)
 	}
 
-	return db, nil
+	t.Cleanup(func() { db.Close() })
+	return db
 }
 
 // OpenDatabaseForTesting implements OpenDatabase and takes an already opened sql.DB.

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -8,18 +8,14 @@ import (
 )
 
 func TestUpdate(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "newpassword"
 	var expectedType PasswordType = "plain"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -58,11 +54,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestPwgenUpdate(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseCommandForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
@@ -70,7 +62,7 @@ func TestPwgenUpdate(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "output-from-pwgen"
 	var expectedType PasswordType = "plain"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -109,18 +101,14 @@ func TestPwgenUpdate(t *testing.T) {
 }
 
 func TestInteractiveUpdate(t *testing.T) {
-	db, err := CreateDatabaseForTesting()
-	defer db.Close()
-	if err != nil {
-		t.Fatalf("CreateDatabaseForTesting() err = %q, want nil", err)
-	}
+	db := CreateDatabaseForTesting(t)
 	UseDatabaseForTesting(t, db)
 	expectedMachine := "mymachine"
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "newpassword"
 	var expectedType PasswordType = "plain"
-	err = initDatabase(db)
+	err := initDatabase(db)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}


### PR DESCRIPTION
Rather than assuming that clients will register some suitable defer
statement.
