### PR TITLE
update -n: check transaction begin error

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -31,6 +31,7 @@ func createPassword(context *Context, machine, service, user, password string, p
 		return "", fmt.Errorf("db.Begin() failed: %s", err)
 	}
 
+	defer transaction.Rollback()
 	query, err := transaction.Prepare("insert into passwords (machine, service, user, password, type) values(?, ?, ?, ?, ?)")
 	if err != nil {
 		return "", fmt.Errorf("db.Prepare() failed: %s", err)
@@ -42,7 +43,6 @@ func createPassword(context *Context, machine, service, user, password string, p
 	}
 
 	if context.DryRun {
-		transaction.Rollback()
 		context.NoWriteBack = true
 	} else {
 		transaction.Commit()

--- a/commands/update.go
+++ b/commands/update.go
@@ -47,6 +47,11 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 			}
 
 			transaction, err := ctx.Database.Begin()
+			if err != nil {
+				return fmt.Errorf("db.Begin() failed: %s", err)
+			}
+
+			defer transaction.Rollback()
 			query, err := transaction.Prepare("update passwords set password=? where machine=? and service=? and user=? and type=?")
 			if err != nil {
 				return fmt.Errorf("db.Prepare() failed: %s", err)
@@ -66,7 +71,6 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 				return fmt.Errorf("result.RowsAffected() failed: %s", err)
 			}
 			if dryRun {
-				transaction.Rollback()
 				fmt.Fprintf(cmd.OutOrStdout(), "Would update %v password\n", affected)
 				ctx.NoWriteBack = true
 			} else {


### PR DESCRIPTION
Also rollback the transaction on error, in both "create -n" and "update
-n".
