### PR TITLE
Add shell completion support

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -80,6 +80,7 @@ func getCommands() []string {
 		"-h",
 		"--help",
 		"completion",
+		"__complete",
 		"create",
 		"delete",
 		"help",
@@ -278,7 +279,6 @@ func Main(input io.Reader, output io.Writer) int {
 	cmd.SetArgs(args)
 	cmd.SetIn(input)
 	cmd.SetOut(output)
-	cmd.SetErr(output)
 
 	err := cmd.Execute()
 	if err != nil {

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -8,8 +8,8 @@ macOS or Windows.
 You need to install [GPG](https://gnupg.org/) if you don't have it already and need to generate at
 least a key using:
 
-```sh
-gpg --gen-key
+```console
+$ gpg --gen-key
 ```
 
 This will allow cpm to encrypt and decrypt your password database. Don't fear from specifying a
@@ -28,9 +28,23 @@ auto-generated passwords.
 
 You can install cpm using:
 
-```sh
-go install vmiklos.hu/go/cpm@latest
+```console
+$ go install vmiklos.hu/go/cpm@latest
 ```
 
 If `$(go env GOPATH)/bin` is not in your `PATH` yet, you may want to add it, so typing `cpm` will
 invoke the installed executable.
+
+## Optional shell completion
+
+Optionally, you can install shell completion for cpm, example for bash:
+
+```console
+$ cpm completion bash |sudo tee /usr/share/bash-completion/completions/cpm
+```
+
+You can test if it works in a new shell using:
+
+```console
+$ cpm <tab><tab>
+```

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+- added shell completion support
+
 ## 7.3
 
 - create: new `-n` switch, introducing a dry run mode to see what style of password would be


### PR DESCRIPTION
One issue was that 'cpm __complete' should not search for __complete but
should actually perform shell completion.

The other issue was that calling SetErr() with os.Stdout resulted in
emitting unwanted debug output. Just remove that redirection, we don't
use ErrOrStderr() anywhere.
