### PR TITLE
Turn the remaining 'sh' snippets into console ones

### DIFF
--- a/guide/src/advanced.md
+++ b/guide/src/advanced.md
@@ -18,7 +18,7 @@ Host cpm
 
 Finally pull the remote database to your local one, using:
 
-```sh
+```console
 cpm sync
 ```
 
@@ -32,7 +32,7 @@ templates, `cpm` can be integrated into such a workflow, using the quiet mode of
 subcommand. For example, if you have an app password at your mail provider, and you want to generate
 your mutt configuration, you can query just the password from `cpm` using:
 
-```sh
+```console
 cpm -q -m accounts.example.com -u $USER-mail-$HOSTNAME
 ```
 
@@ -42,7 +42,7 @@ In case you used the old `cpm` tool, it used to store its data at `~/.cpmdb` as 
 compressed and encrypted. If you want to import that into turtle-cpm's database, you can do so
 using:
 
-```sh
+```console
 cpm import
 ```
 
@@ -51,13 +51,13 @@ cpm import
 In case you want to inspect the SQLite database of `cpm` manually, you need to decrypt it yourself,
 using (assuming an empty `XDG_STATE_HOME` environment variable):
 
-```sh
+```console
 gpg --decrypt -a -o decrypted.db ~/.local/state/cpm/passwords.db
 ```
 
 After this, you can inspect the database using a GUI like:
 
-```sh
+```console
 sqlitebrowser decrypted.db
 ```
 
@@ -68,13 +68,13 @@ Don't forget to delete the decrypted database after you're done with your invest
 Apart from this guide, reference documentation is available in `cpm` itself. You can learn about the
 possible subcommands using:
 
-```sh
+```console
 cpm -h
 ```
 
 You can also check all the available options for one given subcommand using e.g.:
 
-```sh
+```console
 cpm create -h
 ```
 
@@ -96,7 +96,7 @@ The benefit of storing the full URL in the `cpm` database is that later you can 
 codes using e.g.:
 
 ```console
-$ cpm -t totp --qrcode twitter
+cpm -t totp --qrcode twitter
 machine: twitter.com, service: http, user: myuser, password type: TOTP shared secret, password:
 ...
 ```

--- a/guide/src/hacking.md
+++ b/guide/src/hacking.md
@@ -2,13 +2,18 @@
 
 ## Updating dependencies
 
-Ideally CI checks everything before a commit hits main, but run `go get -u && go mod tidy` from time
-to time and make sure Go dependencies are reasonably up to date.
+Ideally CI checks everything before a commit hits main, but run
+
+```console
+go get -u && go mod tidy
+```
+
+from time to time and make sure Go dependencies are reasonably up to date.
 
 ## Shell completion
 
 Changes to the shell completion can be tested, without restarting the shell using:
 
 ```console
-$ source <(cpm completion bash)
+source <(cpm completion bash)
 ```

--- a/guide/src/installation.md
+++ b/guide/src/installation.md
@@ -9,7 +9,7 @@ You need to install [GPG](https://gnupg.org/) if you don't have it already and n
 least a key using:
 
 ```console
-$ gpg --gen-key
+gpg --gen-key
 ```
 
 This will allow cpm to encrypt and decrypt your password database. Don't fear from specifying a
@@ -29,7 +29,7 @@ auto-generated passwords.
 You can install cpm using:
 
 ```console
-$ go install vmiklos.hu/go/cpm@latest
+go install vmiklos.hu/go/cpm@latest
 ```
 
 If `$(go env GOPATH)/bin` is not in your `PATH` yet, you may want to add it, so typing `cpm` will
@@ -40,11 +40,11 @@ invoke the installed executable.
 Optionally, you can install shell completion for cpm, example for bash:
 
 ```console
-$ cpm completion bash |sudo tee /usr/share/bash-completion/completions/cpm
+cpm completion bash > ~/.local/share/bash-completion/completions/cpm
 ```
 
 You can test if it works in a new shell using:
 
 ```console
-$ cpm <tab><tab>
+cpm <tab><tab>
 ```

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -25,7 +25,7 @@ Specifying parameters can be useful if:
 Example for such usage:
 
 ```console
-$ cpm create -m example.com -s http -u myuser -t plain -p 7U1FvIzubR95Itg
+cpm create -m example.com -s http -u myuser -t plain -p 7U1FvIzubR95Itg
 ```
 
 When the machine is not yours, it can be e.g. the domain of a website.
@@ -60,7 +60,7 @@ TOTP is one from of Two-Factor Authentication (2FA), currently used by many popu
 shared secret and then add it to cpm using:
 
 ```console
-$ cpm create -m mymachine -u myuser -p "MY TOTP SHARED SECRET" -t totp
+cpm create -m mymachine -u myuser -p "MY TOTP SHARED SECRET" -t totp
 ```
 
 When searching, it's a good idea to first narrow down your search results to a single hit, e.g.


### PR DESCRIPTION
Mostly because these are not snippets in the bash programming language
but they show you what commands to copy&paste.

Also remove the leading dollar sign, unless the snippet shows both a
typed command its output. This helps when tripple-click is used to
select the full line and the dollar sign would get into the reader's
way.
