### PR TITLE
search: display password ID in the output by default

### DIFF
--- a/commands/create_test.go
+++ b/commands/create_test.go
@@ -29,7 +29,9 @@ func TestInsert(t *testing.T) {
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}
@@ -65,7 +67,9 @@ func TestNoServiceInsert(t *testing.T) {
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}
@@ -103,7 +107,9 @@ func TestPwgenInsert(t *testing.T) {
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}
@@ -193,7 +199,9 @@ func TestInteractiveInsert(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}

--- a/commands/import_test.go
+++ b/commands/import_test.go
@@ -25,7 +25,9 @@ func TestImport(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}

--- a/commands/read_test.go
+++ b/commands/read_test.go
@@ -20,7 +20,7 @@ func TestSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "search", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
+	os.Args = []string{"", "search", "--noid", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -77,7 +77,7 @@ func TestSelectTotpCode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "search", "--totp", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
+	os.Args = []string{"", "search", "--noid", "--totp", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -112,7 +112,7 @@ func TestQrcodeSelect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "search", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser, "--qrcode"}
+	os.Args = []string{"", "search", "--noid", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser, "--qrcode"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -140,7 +140,7 @@ func TestSelectMachineFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "search", "-m", "mymachine1"}
+	os.Args = []string{"", "search", "--noid", "-m", "mymachine1"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -168,7 +168,7 @@ func TestSelectServiceFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "search", "-s", "myservice1"}
+	os.Args = []string{"", "search", "--noid", "-s", "myservice1"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -196,7 +196,7 @@ func TestSelectUserFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "search", "-u", "myuser1"}
+	os.Args = []string{"", "search", "--noid", "-u", "myuser1"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -224,7 +224,7 @@ func TestSelectTypeFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "search", "-t", "totp"}
+	os.Args = []string{"", "search", "--noid", "-t", "totp"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -253,7 +253,7 @@ func TestSelectImplicitFilter(t *testing.T) {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
 	// Implicit search, also not telling that myservice1 is a service.
-	os.Args = []string{"", "myservice1"}
+	os.Args = []string{"", "--noid", "myservice1"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -282,7 +282,7 @@ func TestSelectInteractive(t *testing.T) {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
 	// Interactive search.
-	os.Args = []string{""}
+	os.Args = []string{"", "--noid"}
 	inBuf := new(bytes.Buffer)
 	inBuf.Write([]byte("mymachine1" + "\n"))
 	outBuf := new(bytes.Buffer)
@@ -327,7 +327,7 @@ func TestOpenCloseDatabase(t *testing.T) {
 		t.Fatalf("Main(create) = %v, want %v, output is %q", actualRet, expectedRet, outBuf.String())
 	}
 
-	os.Args = []string{"", "search", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
+	os.Args = []string{"", "search", "--noid", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
 	inBuf = new(bytes.Buffer)
 	outBuf = new(bytes.Buffer)
 

--- a/commands/sync_test.go
+++ b/commands/sync_test.go
@@ -35,7 +35,7 @@ func TestSync(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main(sync) = %v, want %v, output is %q", actualRet, expectedRet, outBuf.String())
 	}
-	os.Args = []string{"", "search", "-m", expectedMachine, "-u", expectedUser}
+	os.Args = []string{"", "search", "--noid", "-m", expectedMachine, "-u", expectedUser}
 	outBuf = new(bytes.Buffer)
 	actualRet = Main(inBuf, outBuf)
 	expectedRet = 0

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -32,7 +32,9 @@ func TestUpdate(t *testing.T) {
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}
@@ -74,7 +76,9 @@ func TestPwgenUpdate(t *testing.T) {
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}
@@ -117,7 +121,9 @@ func TestInteractiveUpdate(t *testing.T) {
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}
@@ -157,7 +163,9 @@ func TestDryRunUpdate(t *testing.T) {
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
 	if err != nil {
 		t.Fatalf("readPasswords() err = %q, want nil", err)
 	}


### PR DESCRIPTION
Will be useful when 'update' will want to refer to this id (as shorter
alternative to machine-service-user-type).
