### PR TITLE
update: add a new -i / --id option

### DIFF
--- a/commands/update.go
+++ b/commands/update.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bufio"
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -15,61 +16,85 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	var password string
 	var passwordType PasswordType = "plain"
 	var dryRun bool
+	var id string
 	var cmd = &cobra.Command{
 		Use:   "update",
 		Short: "updates an existing password",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			reader := bufio.NewReader(cmd.InOrStdin())
-			if len(machine) == 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "Machine: ")
-				line, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("ReadString() failed: %s", err)
-				}
-				machine = strings.TrimSuffix(line, "\n")
-			}
-			if len(user) == 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "User: ")
-				line, err := reader.ReadString('\n')
-				if err != nil {
-					return fmt.Errorf("ReadString() failed: %s", err)
-				}
-				user = strings.TrimSuffix(line, "\n")
-			}
-
-			generatedPassword := password
-			if len(password) == 0 {
-				var err error
-				generatedPassword, err = generatePassword()
-				if err != nil {
-					return fmt.Errorf("generatePassword() failed: %s", err)
-				}
-			}
-
 			transaction, err := ctx.Database.Begin()
 			if err != nil {
 				return fmt.Errorf("db.Begin() failed: %s", err)
 			}
 
 			defer transaction.Rollback()
-			query, err := transaction.Prepare("update passwords set password=? where machine=? and service=? and user=? and type=?")
-			if err != nil {
-				return fmt.Errorf("db.Prepare() failed: %s", err)
+
+			var affected int64
+			if len(id) > 0 {
+				var result sql.Result
+				if len(machine) > 0 {
+					query, err := transaction.Prepare("update passwords set machine=? where id=?")
+					if err != nil {
+						return fmt.Errorf("db.Prepare() failed: %s", err)
+					}
+
+					result, err = query.Exec(machine, id)
+					if err != nil {
+						return fmt.Errorf("db.Exec() failed: %s", err)
+					}
+				}
+
+				affected, err = result.RowsAffected()
+				if err != nil {
+					return fmt.Errorf("result.RowsAffected() failed: %s", err)
+				}
+			} else {
+				reader := bufio.NewReader(cmd.InOrStdin())
+				if len(machine) == 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "Machine: ")
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						return fmt.Errorf("ReadString() failed: %s", err)
+					}
+					machine = strings.TrimSuffix(line, "\n")
+				}
+				if len(user) == 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "User: ")
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						return fmt.Errorf("ReadString() failed: %s", err)
+					}
+					user = strings.TrimSuffix(line, "\n")
+				}
+
+				generatedPassword := password
+				if len(password) == 0 {
+					var err error
+					generatedPassword, err = generatePassword()
+					if err != nil {
+						return fmt.Errorf("generatePassword() failed: %s", err)
+					}
+				}
+
+				query, err := transaction.Prepare("update passwords set password=? where machine=? and service=? and user=? and type=?")
+				if err != nil {
+					return fmt.Errorf("db.Prepare() failed: %s", err)
+				}
+
+				result, err := query.Exec(generatedPassword, machine, service, user, passwordType)
+				if err != nil {
+					return fmt.Errorf("db.Exec() failed: %s", err)
+				}
+
+				if generatedPassword != password {
+					fmt.Fprintf(cmd.OutOrStdout(), "Generated new password: %s\n", generatedPassword)
+				}
+
+				affected, err = result.RowsAffected()
+				if err != nil {
+					return fmt.Errorf("result.RowsAffected() failed: %s", err)
+				}
 			}
 
-			result, err := query.Exec(generatedPassword, machine, service, user, passwordType)
-			if err != nil {
-				return fmt.Errorf("db.Exec() failed: %s", err)
-			}
-
-			if generatedPassword != password {
-				fmt.Fprintf(cmd.OutOrStdout(), "Generated new password: %s\n", generatedPassword)
-			}
-
-			affected, err := result.RowsAffected()
-			if err != nil {
-				return fmt.Errorf("result.RowsAffected() failed: %s", err)
-			}
 			if dryRun {
 				fmt.Fprintf(cmd.OutOrStdout(), "Would update %v password\n", affected)
 				ctx.NoWriteBack = true
@@ -77,7 +102,6 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 				transaction.Commit()
 				fmt.Fprintf(cmd.OutOrStdout(), "Updated %v password\n", affected)
 			}
-
 			return nil
 		},
 	}
@@ -87,6 +111,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	cmd.Flags().StringVarP(&password, "password", "p", "", "new password")
 	cmd.Flags().VarP(&passwordType, "type", "t", `password type ("plain" or "totp")`)
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, `do everything except actually perform the database action (default: false)`)
+	cmd.Flags().StringVarP(&id, "id", "i", "", `other parameters specify new values for this id (default: '')`)
 
 	return cmd
 }

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -181,3 +181,46 @@ func TestDryRunUpdate(t *testing.T) {
 		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)
 	}
 }
+
+func TestUpdateMachine(t *testing.T) {
+	ctx := CreateContextForTesting(t)
+	expectedMachine := "mymachine"
+	expectedService := "myservice"
+	expectedUser := "myuser"
+	var expectedType PasswordType = "plain"
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	if err != nil {
+		t.Fatalf("createPassword() = %q, want nil", err)
+	}
+	expectedMachine = "mymachine2"
+	os.Args = []string{"", "update", "--id", "1", "-m", expectedMachine}
+	inBuf := new(bytes.Buffer)
+	outBuf := new(bytes.Buffer)
+
+	actualRet := Main(inBuf, outBuf)
+
+	expectedRet := 0
+	if actualRet != expectedRet {
+		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
+	}
+	expectedBuf := "Updated 1 password\n"
+	if outBuf.String() != expectedBuf {
+		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
+	}
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
+	if err != nil {
+		t.Fatalf("readPasswords() err = %q, want nil", err)
+	}
+	actualLength := len(results)
+	expectedLength := 1
+	if actualLength != expectedLength {
+		t.Fatalf("actualLength = %q, want %q", actualLength, expectedLength)
+	}
+	actualContains := ContainsString(results, fmt.Sprintf("machine: %s, service: %s, user: %s, password type: %s, password: %s", expectedMachine, expectedService, expectedUser, expectedType, "oldpassword"))
+	expectedContains := true
+	if actualContains != expectedContains {
+		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)
+	}
+}

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+- update: new `-i` switch to edit the `machine` of a password without changing the password itself
+
 ## 7.4
 
 - added shell completion support

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -50,7 +50,7 @@ You'll have to provide a search term:
 
 ```console
 Search term: example.com
-machine: example.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
+id:        1, machine: example.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
 ```
 
 The search term can also be specified as an argument if non-interactive mode is wanted.
@@ -64,7 +64,7 @@ cpm search -m example.com -s http -u myuser -t plain
 The search term is already specified in this case:
 
 ```
-machine: example.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
+id:        1, machine: example.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
 ```
 
 ## TOTP support
@@ -88,8 +88,8 @@ cpm twitter
 The search term is already specified in this case:
 
 ```
-machine: twitter.com, service: http, user: myuser, password type: plain, password: ...
-machine: twitter.com, service: http, user: myuser, password type: TOTP shared secret, password: ...
+id:        1, machine: twitter.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
+id:        2, machine: twitter.com, service: http, user: myuser, password type: TOTP shared secret, password: ...
 ```
 
 just returns your password and your TOTP shared secret, and then you can generate the current TOTP
@@ -102,7 +102,7 @@ cpm --totp twitter
 The search term is already specified in this case:
 
 ```console
-machine: twitter.com, service: http, user: myuser, password type: TOTP code, password: ...
+id:        2, machine: twitter.com, service: http, user: myuser, password type: TOTP code, password: ...
 ```
 
 ## Update and deletion
@@ -132,6 +132,13 @@ You'll see the amount of updated passwords:
 
 ```console
 Updated 1 password
+```
+
+If you want to update some property other than the password itself, then for use `cpm search` to
+find its ID, then you can edit based on that ID:
+
+```
+cpm update -i <id> -m example2.com
 ```
 
 Finally if you want to delete a password, you can do so by using:

--- a/man/cpm-search.1
+++ b/man/cpm-search.1
@@ -26,6 +26,10 @@ searches passwords
 	machine (default: "")
 
 .PP
+\fB-I\fP, \fB--noid\fP[=false]
+	noid mode: omit password ID from the output (default: false)
+
+.PP
 \fB-Q\fP, \fB--qrcode\fP[=false]
 	qrcode mode: print the TOTP shared secret as a QR code (default: false)
 

--- a/man/cpm-update.1
+++ b/man/cpm-update.1
@@ -26,6 +26,10 @@ updates an existing password
 	help for update
 
 .PP
+\fB-i\fP, \fB--id\fP=""
+	other parameters specify new values for this id (default: '')
+
+.PP
 \fB-m\fP, \fB--machine\fP=""
 	machine (default: ask)
 


### PR DESCRIPTION
E.g. if a machine gets renamed, then search for the id, then:

cpm update -i <id> -m <new name of machine>

can do such a rename, which was not possible before.
