### PR TITLE
Fix version subcommand with go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,11 @@ GO_OBJECTS = \
 	man/generate.go \
 
 COMMANDS_PATH = vmiklos.hu/go/cpm/commands
-LDFLAGS = -X ${COMMANDS_PATH}.GitCommit=$(shell git describe)
 
 build: turtle-cpm
 
 turtle-cpm: Makefile ${GO_OBJECTS}
-	go build -ldflags "$(LDFLAGS)" .
+	go build .
 
 check: build check-format check-lint check-unit
 	@echo "make check: ok"
@@ -37,7 +36,7 @@ check-format:
 
 # Without coverage: 'go test ./...'.
 check-unit:
-	go build -ldflags "$(LDFLAGS)" ./...
+	go build ./...
 	courtney -e ./...
 
 generate-man:

--- a/commands/root.go
+++ b/commands/root.go
@@ -18,10 +18,9 @@ import (
 
 const (
 	xdgStateHome = "XDG_STATE_HOME"
+	// Version specifies the number for the version subcommand
+	Version = "7.4"
 )
-
-// GitCommit is initialized externally during the build. See the Makefile.
-var GitCommit string
 
 // Command returns the Cmd struct to execute the named program
 var Command = exec.Command

--- a/commands/version.go
+++ b/commands/version.go
@@ -11,7 +11,7 @@ func newVersionCommand(ctx *Context) *cobra.Command {
 		Use:   "version",
 		Short: "shows version information",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "turtle-cpm %s\n", GitCommit)
+			fmt.Fprintf(cmd.OutOrStdout(), "turtle-cpm version %s\n", Version)
 			ctx.NoWriteBack = true
 			return nil
 		},


### PR DESCRIPTION
Which doesn't use the Makefile, so the version was missing there.
