### PR TITLE
update -i: handle -u

### DIFF
--- a/commands/update.go
+++ b/commands/update.go
@@ -53,6 +53,17 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 						return fmt.Errorf("db.Exec() failed: %s", err)
 					}
 				}
+				if len(user) > 0 {
+					query, err := transaction.Prepare("update passwords set user=? where id=?")
+					if err != nil {
+						return fmt.Errorf("db.Prepare() failed: %s", err)
+					}
+
+					result, err = query.Exec(user, id)
+					if err != nil {
+						return fmt.Errorf("db.Exec() failed: %s", err)
+					}
+				}
 
 				affected, err = result.RowsAffected()
 				if err != nil {

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -268,3 +268,46 @@ func TestUpdateService(t *testing.T) {
 		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)
 	}
 }
+
+func TestUpdateUser(t *testing.T) {
+	ctx := CreateContextForTesting(t)
+	expectedMachine := "mymachine"
+	expectedService := "myservice"
+	expectedUser := "myuser"
+	var expectedType PasswordType = "plain"
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	if err != nil {
+		t.Fatalf("createPassword() = %q, want nil", err)
+	}
+	expectedUser = "myuser2"
+	os.Args = []string{"", "update", "--id", "1", "-u", expectedUser}
+	inBuf := new(bytes.Buffer)
+	outBuf := new(bytes.Buffer)
+
+	actualRet := Main(inBuf, outBuf)
+
+	expectedRet := 0
+	if actualRet != expectedRet {
+		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
+	}
+	expectedBuf := "Updated 1 password\n"
+	if outBuf.String() != expectedBuf {
+		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
+	}
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
+	if err != nil {
+		t.Fatalf("readPasswords() err = %q, want nil", err)
+	}
+	actualLength := len(results)
+	expectedLength := 1
+	if actualLength != expectedLength {
+		t.Fatalf("actualLength = %q, want %q", actualLength, expectedLength)
+	}
+	actualContains := ContainsString(results, fmt.Sprintf("machine: %s, service: %s, user: %s, password type: %s, password: %s", expectedMachine, expectedService, expectedUser, expectedType, "oldpassword"))
+	expectedContains := true
+	if actualContains != expectedContains {
+		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)
+	}
+}

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -2,7 +2,8 @@
 
 ## main
 
-- update: new `-i` switch to edit the `machine` or `service` of a password without changing the password itself
+- update: new `-i` switch to edit the `machine`, `service` or `user` of a password without changing
+  the password itself
 
 ## 7.4
 


### PR DESCRIPTION
I.e. renaming (with unchanged password) can now handle user.

Use-case is an app-specific password, e.g. you have multiple passwords
for the same machine/service and you transwer one user/pass pair from
one machine to an other, and unless the user is renamed, some script
looking for <some-prefix>-$HOST won't find the password without
renaming.
