### PR TITLE
Rename cpm sync to cpm pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ GO_OBJECTS = \
 	commands/delete_test.go \
 	commands/import.go \
 	commands/import_test.go \
+	commands/pull.go \
+	commands/pull.go \
 	commands/read.go \
 	commands/read_test.go \
 	commands/root.go \
 	commands/root_test.go \
-	commands/sync.go \
-	commands/sync_test.go \
 	commands/update.go \
 	commands/update_test.go \
 	commands/version.go \

--- a/commands/pull.go
+++ b/commands/pull.go
@@ -6,9 +6,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSyncCommand(ctx *Context) *cobra.Command {
+func newPullCommand(ctx *Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "sync",
+		Use:   "pull",
 		Short: "copies a remote database to a local one",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			databasePath, err := getDatabasePath()

--- a/commands/pull_test.go
+++ b/commands/pull_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestSync(t *testing.T) {
+func TestPull(t *testing.T) {
 	UseCommandForTesting(t)
 	OldRemove := Remove
 	Remove = RemoveForTesting
@@ -26,14 +26,14 @@ func TestSync(t *testing.T) {
 		t.Fatalf("Main(create) = %v, want %v, output is %q", actualRet, expectedRet, outBuf.String())
 	}
 	os.Rename("fixtures/passwords.db", "fixtures/remote.db")
-	os.Args = []string{"", "sync"}
+	os.Args = []string{"", "pull"}
 	outBuf = new(bytes.Buffer)
 
 	actualRet = Main(inBuf, outBuf)
 
 	expectedRet = 0
 	if actualRet != expectedRet {
-		t.Fatalf("Main(sync) = %v, want %v, output is %q", actualRet, expectedRet, outBuf.String())
+		t.Fatalf("Main(pull) = %v, want %v, output is %q", actualRet, expectedRet, outBuf.String())
 	}
 	os.Args = []string{"", "search", "--noid", "-m", expectedMachine, "-u", expectedUser}
 	outBuf = new(bytes.Buffer)

--- a/commands/root.go
+++ b/commands/root.go
@@ -68,7 +68,7 @@ func NewRootCommand(ctx *Context) *cobra.Command {
 	cmd.AddCommand(newUpdateCommand(ctx))
 	cmd.AddCommand(newDeleteCommand(ctx))
 	cmd.AddCommand(newImportCommand(ctx))
-	cmd.AddCommand(newSyncCommand(ctx))
+	cmd.AddCommand(newPullCommand(ctx))
 	cmd.AddCommand(newVersionCommand(ctx))
 
 	return cmd
@@ -84,9 +84,9 @@ func getCommands() []string {
 		"delete",
 		"help",
 		"import",
+		"pull",
 		"search",
 		"update",
-		"sync",
 		"version",
 	}
 }

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -16,7 +16,7 @@ func TestVersion(t *testing.T) {
 
 	expectedRet := 0
 	if actualRet != expectedRet {
-		t.Fatalf("Main(sync) = %v, want %v, output is %q", actualRet, expectedRet, outBuf.String())
+		t.Fatalf("Main(version) = %v, want %v, output is %q", actualRet, expectedRet, outBuf.String())
 	}
 	expectedPrefix := "turtle-cpm "
 	actualOutput := outBuf.String()

--- a/guide/src/advanced.md
+++ b/guide/src/advanced.md
@@ -19,11 +19,11 @@ Host cpm
 Finally pull the remote database to your local one, using:
 
 ```console
-cpm sync
+cpm pull
 ```
 
 This allows searching in your passwords even when you're offline. Keep in mind that editing the
-database on the slaves is not a good idea as the next sync will overwrite your local changes.
+database on the slaves is not a good idea as the next pull will overwrite your local changes.
 
 ## Toolkit integration
 

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -4,6 +4,7 @@
 
 - update: new `-i` switch to edit the `machine`, `service` or `user` of a password without changing
   the password itself
+- `sync` is renamed to `pull`, since it's a remote -> local copy only
 
 ## 7.4
 

--- a/man/cpm-pull.1
+++ b/man/cpm-pull.1
@@ -3,12 +3,12 @@
 
 .SH NAME
 .PP
-cpm-sync - copies a remote database to a local one
+cpm-pull - copies a remote database to a local one
 
 
 .SH SYNOPSIS
 .PP
-\fBcpm sync [flags]\fP
+\fBcpm pull [flags]\fP
 
 
 .SH DESCRIPTION
@@ -19,7 +19,7 @@ copies a remote database to a local one
 .SH OPTIONS
 .PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for sync
+	help for pull
 
 
 .SH SEE ALSO

--- a/man/cpm-update.1
+++ b/man/cpm-update.1
@@ -38,7 +38,7 @@ updates an existing password
 	new password
 
 .PP
-\fB-s\fP, \fB--service\fP="http"
+\fB-s\fP, \fB--service\fP=""
 	service
 
 .PP

--- a/man/cpm.1
+++ b/man/cpm.1
@@ -24,7 +24,7 @@ turtle-cpm is a console password manager
 
 .SH SEE ALSO
 .PP
-\fBcpm-create(1)\fP, \fBcpm-delete(1)\fP, \fBcpm-import(1)\fP, \fBcpm-search(1)\fP, \fBcpm-sync(1)\fP, \fBcpm-update(1)\fP, \fBcpm-version(1)\fP
+\fBcpm-create(1)\fP, \fBcpm-delete(1)\fP, \fBcpm-import(1)\fP, \fBcpm-pull(1)\fP, \fBcpm-search(1)\fP, \fBcpm-update(1)\fP, \fBcpm-version(1)\fP
 
 
 .SH HISTORY


### PR DESCRIPTION
Because it's one-direction only, to avoid confusion.
