### PR TITLE
create -n: be more explicit about nothing was created due to dry-run

### DIFF
--- a/commands/create_test.go
+++ b/commands/create_test.go
@@ -25,7 +25,7 @@ func TestInsert(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedBuf := ""
+	expectedBuf := "Created 1 password\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
@@ -63,7 +63,7 @@ func TestNoServiceInsert(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedBuf := ""
+	expectedBuf := "Created 1 password\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
@@ -103,7 +103,7 @@ func TestPwgenInsert(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedBuf := "Generated password: output-from-pwgen\n"
+	expectedBuf := "Created 1 password\nGenerated password: output-from-pwgen\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
@@ -191,7 +191,7 @@ func TestInteractiveInsert(t *testing.T) {
 
 	actualRet := Main(inBuf, outBuf)
 
-	expectedBuf := "Machine: User: "
+	expectedBuf := "Machine: User: Created 1 password\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
@@ -233,7 +233,7 @@ func TestDryRunInsert(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedBuf := ""
+	expectedBuf := "Would create 1 password\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}

--- a/commands/root.go
+++ b/commands/root.go
@@ -99,6 +99,7 @@ type Context struct {
 	NoWriteBack      bool
 	DryRun           bool
 	DatabaseMigrated bool
+	OutOrStdout      *io.Writer
 }
 
 func pathExists(path string) bool {

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## main
+
+- `create` / `create -n` now confirms if the password was actually created or it only would be
+  created.
+
 ## 7.5
 
 - update: new `-i` switch to edit the `machine`, `service` or `user` of a password without changing


### PR DESCRIPTION
`create -n` is nice to be used as a simple password generator, but then
-n should say it explicitly that the DB was not touched to suggest more
safety.
