### PR TITLE
delete: always select password using an ID

### DIFF
--- a/commands/delete.go
+++ b/commands/delete.go
@@ -9,10 +9,6 @@ import (
 )
 
 func newDeleteCommand(ctx *Context) *cobra.Command {
-	var machine string
-	var service string
-	var user string
-	var passwordType PasswordType = "plain"
 	var dryRun bool
 	var id string
 	var cmd = &cobra.Command{
@@ -27,54 +23,28 @@ func newDeleteCommand(ctx *Context) *cobra.Command {
 			defer transaction.Rollback()
 
 			var affected int64
-			if len(id) > 0 {
-				query, err := transaction.Prepare("delete from passwords where id=?")
-				if err != nil {
-					return fmt.Errorf("db.Prepare() failed: %s", err)
-				}
-
-				result, err := query.Exec(id)
-				if err != nil {
-					return fmt.Errorf("db.Exec() failed: %s", err)
-				}
-
-				affected, err = result.RowsAffected()
-				if err != nil {
-					return fmt.Errorf("result.RowsAffected() failed: %s", err)
-				}
-			} else {
+			if len(id) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "Id: ")
 				reader := bufio.NewReader(cmd.InOrStdin())
-				if len(machine) == 0 {
-					fmt.Fprintf(cmd.OutOrStdout(), "Machine: ")
-					line, err := reader.ReadString('\n')
-					if err != nil {
-						return fmt.Errorf("ReadString() failed: %s", err)
-					}
-					machine = strings.TrimSuffix(line, "\n")
-				}
-				if len(user) == 0 {
-					fmt.Fprintf(cmd.OutOrStdout(), "User: ")
-					line, err := reader.ReadString('\n')
-					if err != nil {
-						return fmt.Errorf("ReadString() failed: %s", err)
-					}
-					user = strings.TrimSuffix(line, "\n")
-				}
-
-				query, err := transaction.Prepare("delete from passwords where machine=? and service=? and user=? and type=?")
+				line, err := reader.ReadString('\n')
 				if err != nil {
-					return fmt.Errorf("db.Prepare() failed: %s", err)
+					return fmt.Errorf("ReadString() failed: %s", err)
 				}
+				id = strings.TrimSuffix(line, "\n")
+			}
+			query, err := transaction.Prepare("delete from passwords where id=?")
+			if err != nil {
+				return fmt.Errorf("db.Prepare() failed: %s", err)
+			}
 
-				result, err := query.Exec(machine, service, user, passwordType)
-				if err != nil {
-					return fmt.Errorf("db.Exec() failed: %s", err)
-				}
+			result, err := query.Exec(id)
+			if err != nil {
+				return fmt.Errorf("db.Exec() failed: %s", err)
+			}
 
-				affected, err = result.RowsAffected()
-				if err != nil {
-					return fmt.Errorf("result.RowsAffected() failed: %s", err)
-				}
+			affected, err = result.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("result.RowsAffected() failed: %s", err)
 			}
 			if dryRun {
 				fmt.Fprintf(cmd.OutOrStdout(), "Would delete %v password\n", affected)
@@ -87,10 +57,6 @@ func newDeleteCommand(ctx *Context) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&machine, "machine", "m", "", "machine (default: ask)")
-	cmd.Flags().StringVarP(&service, "service", "s", "http", "service")
-	cmd.Flags().StringVarP(&user, "user", "u", "", "user (default: ask)")
-	cmd.Flags().VarP(&passwordType, "type", "t", `password type ("plain" or "totp")`)
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, `do everything except actually perform the database action (default: false)`)
 	cmd.Flags().StringVarP(&id, "id", "i", "", `unique identifier (default: '')`)
 

--- a/commands/delete_test.go
+++ b/commands/delete_test.go
@@ -17,38 +17,6 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "delete", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
-	inBuf := new(bytes.Buffer)
-	outBuf := new(bytes.Buffer)
-
-	actualRet := Main(inBuf, outBuf)
-
-	expectedRet := 0
-	if actualRet != expectedRet {
-		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
-	}
-	results, err := readPasswords(ctx.Database, searchOptions{})
-	if err != nil {
-		t.Fatalf("readPasswords() err = %q, want nil", err)
-	}
-	actualLength := len(results)
-	expectedLength := 0
-	if actualLength != expectedLength {
-		t.Fatalf("actualLength = %q, want %q", actualLength, expectedLength)
-	}
-}
-
-func TestDeleteById(t *testing.T) {
-	ctx := CreateContextForTesting(t)
-	expectedMachine := "mymachine"
-	expectedService := "myservice"
-	expectedUser := "myuser"
-	expectedPassword := "mypassword"
-	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
-	if err != nil {
-		t.Fatalf("createPassword() = %q, want nil", err)
-	}
 	os.Args = []string{"", "delete", "--id", "1"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
@@ -81,9 +49,9 @@ func TestInteractiveDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "delete", "-s", expectedService}
+	os.Args = []string{"", "delete"}
 	inBuf := new(bytes.Buffer)
-	inBuf.Write([]byte(expectedMachine + "\n" + expectedUser + "\n"))
+	inBuf.Write([]byte("1\n"))
 	outBuf := new(bytes.Buffer)
 
 	actualRet := Main(inBuf, outBuf)
@@ -92,7 +60,7 @@ func TestInteractiveDelete(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedBuf := "Machine: User: "
+	expectedBuf := "Id: "
 	expectedBuf += "Deleted 1 password\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
@@ -119,7 +87,7 @@ func TestDryRunDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "delete", "-n", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
+	os.Args = []string{"", "delete", "-n", "-i", "1"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -6,6 +6,8 @@
   created.
 - [pwgen](http://sourceforge.net/projects/pwgen/) installation is not necessary, `cpm` now uses
   [go-password](https://github.com/sethvargo/go-password) instead.
+- `delete` now has only a single way to select which password to delete: the ID has to be specified
+  using `-i` or interactively.
 
 ## 7.5
 

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -147,18 +147,17 @@ Finally if you want to delete a password, you can do so by using:
 cpm delete
 ```
 
-You'll have to specify the machine and the user:
+You'll have to specify the ID:
 
 ```console:
-Machine: mymachine
-User: myuser
+Id: 2
 Deleted 1 password
 ```
 
-You can also specify parameters for `cpm delete`:
+You can also specify a parameter for `cpm delete`:
 
 ```console
-cpm delete -m mymachine -s myservice -u myuser -t plain
+cpm delete -i 2
 ```
 
 In which case the command is not interactive:
@@ -167,9 +166,4 @@ In which case the command is not interactive:
 Deleted 1 password
 ```
 
-An alternative approach is to use `cpm search` to find the password ID, then you can delete based on
-that ID:
-
-```
-cpm delete -i <id>
-```
+You can use `cpm search` to find the password ID.

--- a/man/cpm-delete.1
+++ b/man/cpm-delete.1
@@ -29,22 +29,6 @@ deletes an existing password
 \fB-i\fP, \fB--id\fP=""
 	unique identifier (default: '')
 
-.PP
-\fB-m\fP, \fB--machine\fP=""
-	machine (default: ask)
-
-.PP
-\fB-s\fP, \fB--service\fP="http"
-	service
-
-.PP
-\fB-t\fP, \fB--type\fP=plain
-	password type ("plain" or "totp")
-
-.PP
-\fB-u\fP, \fB--user\fP=""
-	user (default: ask)
-
 
 .SH SEE ALSO
 .PP


### PR DESCRIPTION
It's less code and specifying all of machine/service/user/type is just
painful.
