### PR TITLE
update: always select password using an ID

### DIFF
--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -13,12 +13,12 @@ func TestUpdate(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	expectedPassword := "newpassword"
-	var expectedType PasswordType = "plain"
+	var expectedType PasswordType = "newtype"
 	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "update", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser, "-p", expectedPassword}
+	os.Args = []string{"", "update", "-i", "1", "-p", expectedPassword}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -62,7 +62,7 @@ func TestPwgenUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "update", "-m", expectedMachine, "-s", expectedService, "-u", expectedUser}
+	os.Args = []string{"", "update", "-i", "1", "-p", "-"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -72,7 +72,7 @@ func TestPwgenUpdate(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedBuf := "Generated new password: output-from-pwgen\nUpdated 1 password\n"
+	expectedBuf := "Updated 1 password\nGenerated password: output-from-pwgen\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
 	}
@@ -105,9 +105,9 @@ func TestInteractiveUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	os.Args = []string{"", "update", "-s", expectedService, "-p", expectedPassword}
+	os.Args = []string{"", "update", "-p", expectedPassword}
 	inBuf := new(bytes.Buffer)
-	inBuf.Write([]byte(expectedMachine + "\n" + expectedUser + "\n"))
+	inBuf.Write([]byte("1\n"))
 	outBuf := new(bytes.Buffer)
 
 	actualRet := Main(inBuf, outBuf)
@@ -116,7 +116,7 @@ func TestInteractiveUpdate(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedBuf := "Machine: User: "
+	expectedBuf := "Id: "
 	expectedBuf += "Updated 1 password\n"
 	if outBuf.String() != expectedBuf {
 		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
@@ -149,8 +149,7 @@ func TestDryRunUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	// Default to the 'http' service.
-	os.Args = []string{"", "update", "-n", "-m", expectedMachine, "-u", expectedUser, "-p", "newpassword"}
+	os.Args = []string{"", "update", "-n", "-i", "1", "-p", "newpassword"}
 	inBuf := new(bytes.Buffer)
 	outBuf := new(bytes.Buffer)
 
@@ -306,6 +305,49 @@ func TestUpdateUser(t *testing.T) {
 		t.Fatalf("actualLength = %q, want %q", actualLength, expectedLength)
 	}
 	actualContains := ContainsString(results, fmt.Sprintf("machine: %s, service: %s, user: %s, password type: %s, password: %s", expectedMachine, expectedService, expectedUser, expectedType, "oldpassword"))
+	expectedContains := true
+	if actualContains != expectedContains {
+		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)
+	}
+}
+
+func TestUpdateType(t *testing.T) {
+	ctx := CreateContextForTesting(t)
+	expectedMachine := "mymachine"
+	expectedService := "myservice"
+	expectedUser := "myuser"
+	expectedType := "plain"
+	expectedPassword := "mypassword"
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, "oldtype")
+	if err != nil {
+		t.Fatalf("createPassword() = %q, want nil", err)
+	}
+	os.Args = []string{"", "update", "--id", "1", "-t", expectedType}
+	inBuf := new(bytes.Buffer)
+	outBuf := new(bytes.Buffer)
+
+	actualRet := Main(inBuf, outBuf)
+
+	expectedRet := 0
+	if actualRet != expectedRet {
+		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
+	}
+	expectedBuf := "Updated 1 password\n"
+	if outBuf.String() != expectedBuf {
+		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
+	}
+	opts := searchOptions{}
+	opts.noid = true
+	results, err := readPasswords(ctx.Database, opts)
+	if err != nil {
+		t.Fatalf("readPasswords() err = %q, want nil", err)
+	}
+	actualLength := len(results)
+	expectedLength := 1
+	if actualLength != expectedLength {
+		t.Fatalf("actualLength = %q, want %q", actualLength, expectedLength)
+	}
+	actualContains := ContainsString(results, fmt.Sprintf("machine: %s, service: %s, user: %s, password type: %s, password: %s", expectedMachine, expectedService, expectedUser, expectedType, expectedPassword))
 	expectedContains := true
 	if actualContains != expectedContains {
 		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -6,6 +6,9 @@
   created.
 - [pwgen](http://sourceforge.net/projects/pwgen/) installation is not necessary, `cpm` now uses
   [go-password](https://github.com/sethvargo/go-password) instead.
+- `update` now has only a single way to select which password to update: the ID has to be specified
+  using `-i` or interactively. This allows updating the password or type to a specified value while
+  only specifying an ID.
 - `delete` now has only a single way to select which password to delete: the ID has to be specified
   using `-i` or interactively.
 

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -78,68 +78,55 @@ shared secret and then add it to cpm using:
 cpm create -m mymachine -u myuser -p "MY TOTP SHARED SECRET" -t totp
 ```
 
-When searching, it's a good idea to first narrow down your search results to a single hit, e.g.
-first confirm that:
+When searching, only the TOTP shared secret is shown by default:
 
 ```console
 cpm twitter
-```
-
-The search term is already specified in this case:
-
-```
 id:        1, machine: twitter.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
 id:        2, machine: twitter.com, service: http, user: myuser, password type: TOTP shared secret, password: ...
 ```
 
-just returns your password and your TOTP shared secret, and then you can generate the current TOTP
-code using:
+You can generate the current TOTP code using:
 
 ```console
 cpm --totp twitter
-```
-
-The search term is already specified in this case:
-
-```console
 id:        2, machine: twitter.com, service: http, user: myuser, password type: TOTP code, password: ...
 ```
 
 ## Update and deletion
 
-Update is quite similar to creation. You can generate a new password using:
+Update is quite similar to creation. If you want to update a password to a new, generated value, you
+can do so by using:
 
 ```console
-cpm update
+cpm update -p -
 ```
 
-You'll have to specify the machine and the user:
+You'll have to specify the ID:
 
-```console
-Machine: example.com
-User: myuser
-Generated new password: D95Rx2PlOcPwKbL
+```console:
+Id: 2
 Updated 1 password
+Generated password: aDu3WwGlVP60HEn
 ```
 
-You can also specify parameters for `cpm update`:
+You can also specify more parameters for `cpm update`:
 
 ```console
-cpm update -m mymachine -s myservice -u myuser -t plain -p mynewpassword
+cpm update -i 2 -p -
 ```
 
-You'll see the amount of updated passwords:
+In which case the command is not interactive:
 
 ```console
 Updated 1 password
+Generated password: Ilsd08zGov5JyBR
 ```
 
-If you want to update some property other than the password itself, then for use `cpm search` to
-find its ID, then you can edit based on that ID:
+You can use `cpm search` to find the password ID.
 
-```
-cpm update -i <id> -m example2.com
-```
+The rest of the `cpm update` parameters allow explicitly setting the
+machine/service/user/type/password of an ID to a new, specified value.
 
 Finally if you want to delete a password, you can do so by using:
 
@@ -166,4 +153,4 @@ In which case the command is not interactive:
 Deleted 1 password
 ```
 
-You can use `cpm search` to find the password ID.
+Again, you can use `cpm search` to find the password ID.

--- a/man/cpm-update.1
+++ b/man/cpm-update.1
@@ -27,27 +27,27 @@ updates an existing password
 
 .PP
 \fB-i\fP, \fB--id\fP=""
-	other parameters specify new values for this id (default: '')
+	unique identifier (default: ask)
 
 .PP
 \fB-m\fP, \fB--machine\fP=""
-	machine (default: ask)
+	new machine (default: keep unchanged)
 
 .PP
 \fB-p\fP, \fB--password\fP=""
-	new password
+	new password ("-" generates a new one; default: keep unchanged)
 
 .PP
 \fB-s\fP, \fB--service\fP=""
-	service
+	new service (default: keep unchanged)
 
 .PP
-\fB-t\fP, \fB--type\fP=plain
-	password type ("plain" or "totp")
+\fB-t\fP, \fB--type\fP=
+	new password type ("plain" or "totp"; default: keep unchanged)
 
 .PP
 \fB-u\fP, \fB--user\fP=""
-	user (default: ask)
+	new user (default: keep unchanged)
 
 
 .SH SEE ALSO


### PR DESCRIPTION
cpm update -i ... -p ... now doesn't crash and specifying all of
machine/service/user/type is just painful.
