### PR TITLE
check-headers: fix missing evaluation of command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ check-lint:
 	golint -set_exit_status ./...
 
 check-headers:
-	addlicense -c '$(git config user.name)' -ignore '.github/**' -l mit -s=only -check .
+	addlicense -c '$(shell git config user.name)' -ignore '.github/**' -l mit -s=only -check .
 
 check-format:
 	[ -z "$(shell gofmt -l ${GO_OBJECTS})" ]


### PR DESCRIPTION
The invocation was taken as-is.
