### PR TITLE
read, totp: strip spaces

### DIFF
--- a/commands/read.go
+++ b/commands/read.go
@@ -21,7 +21,8 @@ import (
 // as-is.
 func parsePassword(s string) (string, error) {
 	if !strings.HasPrefix(s, "otpauth://") {
-		return s, nil
+		// Strip spaces, oathtool does this as well.
+		return strings.ReplaceAll(s, " ", ""), nil
 	}
 
 	u, err := url.Parse(s)


### PR DESCRIPTION
E.g. facebook likes to hand out shared secrets like this; oathtool used
to strip them, but totp.GenerateCode() fails for such input.
