### PR TITLE
guide: add note about lack of telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ check-lint:
 	golint -set_exit_status ./...
 
 check-headers:
-	addlicense -c '$(shell git config user.name)' -ignore '.github/**' -l mit -s=only -check .
+	addlicense -c '$(shell git config user.name)' -ignore '.github/**' -ignore 'guide/book/**' -l mit -s=only -check .
 
 check-format:
 	[ -z "$(shell gofmt -l ${GO_OBJECTS})" ]

--- a/guide/src/README.md
+++ b/guide/src/README.md
@@ -15,6 +15,9 @@ Notable features:
 - A little bit better than trivial search: you can search for e.g. `ldap` or `mybank` without
   telling if you are searching for a service type or machine name
 
+Naturally it lacks telemetry, unlike e.g.
+[1Password](https://blog.1password.com/privacy-preserving-app-telemetry/).
+
 ## Website
 
 Check out the [project's website](https://vmiklos.hu/turtle-cpm/) for a list of features and


### PR DESCRIPTION
And ignore license check in the generated guide content.
