### PR TITLE
create / update: add a new '-y' switch

### DIFF
--- a/commands/create_test.go
+++ b/commands/create_test.go
@@ -90,7 +90,22 @@ func TestNoServiceInsert(t *testing.T) {
 }
 
 func GeneratePasswordForTesting(length, numDigits, numSymbols int, noUpper, allowRepeat bool) (string, error) {
+	if numSymbols > 0 {
+		return "0utput-from-pwgen", nil
+	}
 	return "output-from-pwgen", nil
+}
+
+func TestGeneratePasswordSecure(t *testing.T) {
+	CreateContextForTesting(t)
+	actualPassword, err := generatePassword( /*secure=*/ true)
+	if err != nil {
+		t.Fatalf("generatePassword() err = %q, want nil", err)
+	}
+	expectedPassword := "0utput-from-pwgen"
+	if actualPassword != expectedPassword {
+		t.Fatalf("actualPassword = %q, want %q", actualPassword, expectedPassword)
+	}
 }
 
 func TestPwgenInsert(t *testing.T) {

--- a/commands/delete_test.go
+++ b/commands/delete_test.go
@@ -17,7 +17,8 @@ func TestDelete(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -49,7 +50,8 @@ func TestInteractiveDelete(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -87,7 +89,8 @@ func TestDryRunDelete(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}

--- a/commands/import.go
+++ b/commands/import.go
@@ -116,7 +116,7 @@ func newImportCommand(ctx *Context) *cobra.Command {
 								passwordType = "plain"
 							}
 
-							_, err = createPassword(ctx, machineLabel, serviceLabel, userLabel, passwordLabel, passwordType)
+							_, err = createPassword(ctx, machineLabel, serviceLabel, userLabel, passwordLabel, passwordType /*secure=*/, false)
 							if err != nil {
 								return fmt.Errorf("createPassword(machine='%s', service='%s', user='%s', type='%s') failed: %s", machineLabel, serviceLabel, userLabel, passwordType, err)
 							}

--- a/commands/read_test.go
+++ b/commands/read_test.go
@@ -25,7 +25,8 @@ func TestSelect(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -53,7 +54,8 @@ func TestQuietSelect(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -82,7 +84,8 @@ func TestSelectTotpCode(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "totppassword"
 	var expectedType PasswordType = "totp"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -117,7 +120,8 @@ func TestQrcodeSelect(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "mypassword"
 	var expectedType PasswordType = "totp"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -141,11 +145,12 @@ func TestQrcodeSelect(t *testing.T) {
 
 func TestSelectMachineFilter(t *testing.T) {
 	ctx := CreateContextForTesting(t)
-	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain")
+	secure := false
+	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain")
+	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -169,11 +174,12 @@ func TestSelectMachineFilter(t *testing.T) {
 
 func TestSelectServiceFilter(t *testing.T) {
 	ctx := CreateContextForTesting(t)
-	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain")
+	secure := false
+	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain")
+	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -197,11 +203,12 @@ func TestSelectServiceFilter(t *testing.T) {
 
 func TestSelectUserFilter(t *testing.T) {
 	ctx := CreateContextForTesting(t)
-	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain")
+	secure := false
+	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain")
+	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -225,11 +232,12 @@ func TestSelectUserFilter(t *testing.T) {
 
 func TestSelectTypeFilter(t *testing.T) {
 	ctx := CreateContextForTesting(t)
-	_, err := createPassword(&ctx, "mymachine", "myservice", "myuser", "mypassword", "plain")
+	secure := false
+	_, err := createPassword(&ctx, "mymachine", "myservice", "myuser", "mypassword", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	_, err = createPassword(&ctx, "mymachine", "myservice", "myuser", "mypassword", "totp")
+	_, err = createPassword(&ctx, "mymachine", "myservice", "myuser", "mypassword", "totp", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -253,11 +261,12 @@ func TestSelectTypeFilter(t *testing.T) {
 
 func TestSelectImplicitFilter(t *testing.T) {
 	ctx := CreateContextForTesting(t)
-	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain")
+	secure := false
+	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain")
+	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -282,11 +291,12 @@ func TestSelectImplicitFilter(t *testing.T) {
 
 func TestSelectInteractive(t *testing.T) {
 	ctx := CreateContextForTesting(t)
-	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain")
+	secure := false
+	_, err := createPassword(&ctx, "mymachine1", "myservice1", "myuser1", "mypassword1", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
-	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain")
+	_, err = createPassword(&ctx, "mymachine2", "myservice2", "myuser2", "mypassword2", "plain", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}

--- a/commands/update.go
+++ b/commands/update.go
@@ -19,6 +19,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	var passwordType PasswordType
 	var password string
 	var dryRun bool
+	var secure bool
 	var id string
 	var cmd = &cobra.Command{
 		Use:   "update",
@@ -108,7 +109,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 			generatedPassword := false
 			if len(password) > 0 {
 				if password == "-" {
-					password, err = generatePassword()
+					password, err = generatePassword(secure)
 					if err != nil {
 						return fmt.Errorf("generatePassword() failed: %s", err)
 					}
@@ -143,6 +144,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, `do everything except actually perform the database action (default: false)`)
+	cmd.Flags().BoolVarP(&secure, "secure", "y", false, `increase number of symbols from 0 to 3 (default: false)`)
 	cmd.Flags().StringVarP(&id, "id", "i", "", `unique identifier (default: ask)`)
 	cmd.Flags().StringVarP(&machine, "machine", "m", "", "new machine (default: keep unchanged)")
 	cmd.Flags().StringVarP(&service, "service", "s", "", "new service (default: keep unchanged)")

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -18,7 +18,8 @@ func TestUpdate(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "newpassword"
 	var expectedType PasswordType = "newtype"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -62,7 +63,8 @@ func TestPwgenUpdate(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "output-from-pwgen"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -105,7 +107,8 @@ func TestInteractiveUpdate(t *testing.T) {
 	expectedUser := "myuser"
 	expectedPassword := "newpassword"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -149,7 +152,8 @@ func TestDryRunUpdate(t *testing.T) {
 	expectedService := "http"
 	expectedUser := "myuser"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -192,7 +196,8 @@ func TestUpdateMachine(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -235,7 +240,8 @@ func TestUpdateService(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -278,7 +284,8 @@ func TestUpdateUser(t *testing.T) {
 	expectedService := "myservice"
 	expectedUser := "myuser"
 	var expectedType PasswordType = "plain"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType)
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, "oldpassword", expectedType, secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}
@@ -322,7 +329,8 @@ func TestUpdateType(t *testing.T) {
 	expectedUser := "myuser"
 	expectedType := "plain"
 	expectedPassword := "mypassword"
-	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, "oldtype")
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, "oldtype", secure)
 	if err != nil {
 		t.Fatalf("createPassword() = %q, want nil", err)
 	}

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## main
+
+- create / update: new `-y` switch to generate more secure passwords (3 instead of 0 numeric
+  symbols)
+
 ## 7.6
 
 - `create` / `create -n` now confirms if the password was actually created or it only would be

--- a/man/cpm-create.1
+++ b/man/cpm-create.1
@@ -34,6 +34,10 @@ creates a new password
 	password (default: generate)
 
 .PP
+\fB-y\fP, \fB--secure\fP[=false]
+	increase number of symbols from 0 to 3 (default: false)
+
+.PP
 \fB-s\fP, \fB--service\fP="http"
 	service
 

--- a/man/cpm-update.1
+++ b/man/cpm-update.1
@@ -38,6 +38,10 @@ updates an existing password
 	new password ("-" generates a new one; default: keep unchanged)
 
 .PP
+\fB-y\fP, \fB--secure\fP[=false]
+	increase number of symbols from 0 to 3 (default: false)
+
+.PP
 \fB-s\fP, \fB--service\fP=""
 	new service (default: keep unchanged)
 


### PR DESCRIPTION
When used, it generates more secure passwords (3 instead of 0 numeric
symbols).
