### PR TITLE
root: simplify database migration

### DIFF
--- a/commands/pull.go
+++ b/commands/pull.go
@@ -26,6 +26,8 @@ func newPullCommand(ctx *Context) *cobra.Command {
 			}
 
 			ctx.NoWriteBack = true
+			// Prefer the pull result over the migration result.
+			ctx.DatabaseMigrated = false
 			return nil
 		},
 	}

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -41,7 +41,7 @@ func CreateContextForTesting(t *testing.T) Context {
 	t.Cleanup(func() { GenerateTotpCode = oldGenerateTotpCode })
 
 	ctx := Context{Database: db}
-	err = initDatabase(&ctx, true)
+	err = initDatabase(&ctx)
 	if err != nil {
 		t.Fatalf("initDatabase() = %q, want nil", err)
 	}
@@ -180,40 +180,5 @@ func TestGetDatabasePath(t *testing.T) {
 	expected := "/tmp/cpm/passwords.db"
 	if actual != expected {
 		t.Fatalf("getDatabasePath() = %q, want %q", actual, expected)
-	}
-}
-
-func TestMigration(t *testing.T) {
-	// Create an in-memory database.
-	db, err := sql.Open("sqlite3", ":memory:")
-	if err != nil {
-		t.Fatalf("sql.Open() failed: %s", err)
-	}
-	ctx := Context{Database: db}
-	err = initDatabaseWithVersion(&ctx, 0)
-	if err != nil {
-		t.Fatalf("initDatabaseWithVersion() failed: %s", err)
-	}
-
-	err = initDatabase(&ctx, false)
-	if err != nil {
-		t.Fatalf("initDatabase() failed: %s", err)
-	}
-
-	var actual int
-	rows, err := db.Query("pragma user_version")
-	if err != nil {
-		t.Fatalf("Query() failed: %s", err)
-	}
-	defer rows.Close()
-	for rows.Next() {
-		err = rows.Scan(&actual)
-		if err != nil {
-			t.Fatalf("rows.Scan() failed: %s", err)
-		}
-	}
-	expected := 1
-	if actual != expected {
-		t.Fatalf("initDatabase() = %q, want %q", actual, expected)
 	}
 }

--- a/guide/src/hacking.md
+++ b/guide/src/hacking.md
@@ -17,3 +17,11 @@ Changes to the shell completion can be tested, without restarting the shell usin
 ```console
 source <(cpm completion bash)
 ```
+
+## Go debugging
+
+To run a single test:
+
+```console
+go test -run=TestInsert ./...
+```

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+- drop compatibility with cpm < 7.5: update from old versions to 24.2 first
+
 ## 24.2
 
 - create / update: new `-y` switch to generate more secure passwords (3 instead of 0 numeric


### PR DESCRIPTION
We had 2 schema states + migration code between the two. Simplify this
to just 2 state, and in the future just migrations have to be added.

This is in preparation of adding created & modified columns for
passwords, where migration will be needed, which is now much simpler.
