### PR TITLE
CI: update deprecated action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Setup Go
-        uses: actions/setup-go@v4.1.0
+        uses: actions/setup-go@v5.0.0
         with:
           go-version: 1.21.x
       - name: Run make check


### PR DESCRIPTION
E.g. <https://github.com/vmiklos/turtle-cpm/actions/runs/8116570353>
shows a warning, this is meant to fix it.
