### PR TITLE
search, update: add support for archiving passwords

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -193,6 +193,28 @@ func initDatabase(ctx *Context) error {
 		ctx.DatabaseMigrated = true
 	}
 
+	if version < 2 {
+		query, err := ctx.Database.Prepare(`alter table passwords add column
+				archived boolean not null check (archived in (1, 0)) default 0`)
+		if err != nil {
+			return fmt.Errorf("db.Prepare() failed: %s", err)
+		}
+		_, err = query.Exec()
+		if err != nil {
+			return fmt.Errorf("db.Exec() failed: %s", err)
+		}
+
+		query, err = ctx.Database.Prepare("pragma user_version = 2")
+		if err != nil {
+			return fmt.Errorf("db.Prepare() failed: %s", err)
+		}
+		_, err = query.Exec()
+		if err != nil {
+			return fmt.Errorf("db.Exec() failed: %s", err)
+		}
+		ctx.DatabaseMigrated = true
+	}
+
 	return nil
 }
 

--- a/commands/update.go
+++ b/commands/update.go
@@ -21,6 +21,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	var dryRun bool
 	var secure bool
 	var id string
+	var archived string
 	var cmd = &cobra.Command{
 		Use:   "update",
 		Short: "updates an existing password",
@@ -130,6 +131,22 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 					return fmt.Errorf("result.RowsAffected() failed: %s", err)
 				}
 			}
+			if len(archived) > 0 {
+				query, err := transaction.Prepare("update passwords set archived=? where id=?")
+				if err != nil {
+					return fmt.Errorf("db.Prepare() failed: %s", err)
+				}
+
+				result, err := query.Exec(archived, id)
+				if err != nil {
+					return fmt.Errorf("db.Exec() failed: %s", err)
+				}
+
+				affected, err = result.RowsAffected()
+				if err != nil {
+					return fmt.Errorf("result.RowsAffected() failed: %s", err)
+				}
+			}
 			if dryRun {
 				fmt.Fprintf(cmd.OutOrStdout(), "Would update %v password\n", affected)
 				ctx.NoWriteBack = true
@@ -151,6 +168,7 @@ func newUpdateCommand(ctx *Context) *cobra.Command {
 	cmd.Flags().StringVarP(&user, "user", "u", "", "new user (default: keep unchanged)")
 	cmd.Flags().VarP(&passwordType, "type", "t", `new password type ("plain" or "totp"; default: keep unchanged)`)
 	cmd.Flags().StringVarP(&password, "password", "p", "", `new password ("-" generates a new one; default: keep unchanged)`)
+	cmd.Flags().StringVarP(&archived, "archived", "a", "", `new archived value (default: keep unchanged)`)
 
 	return cmd
 }

--- a/commands/update_test.go
+++ b/commands/update_test.go
@@ -365,3 +365,48 @@ func TestUpdateType(t *testing.T) {
 		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)
 	}
 }
+
+func TestUpdateArchived(t *testing.T) {
+	ctx := CreateContextForTesting(t)
+	expectedMachine := "mymachine"
+	expectedService := "myservice"
+	expectedUser := "myuser"
+	expectedArchived := "1"
+	expectedPassword := "mypassword"
+	secure := false
+	_, err := createPassword(&ctx, expectedMachine, expectedService, expectedUser, expectedPassword, "plain", secure)
+	if err != nil {
+		t.Fatalf("createPassword() = %q, want nil", err)
+	}
+	os.Args = []string{"", "update", "--id", "1", "-a", expectedArchived}
+	inBuf := new(bytes.Buffer)
+	outBuf := new(bytes.Buffer)
+
+	actualRet := Main(inBuf, outBuf)
+
+	expectedRet := 0
+	if actualRet != expectedRet {
+		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
+	}
+	expectedBuf := "Updated 1 password\n"
+	if outBuf.String() != expectedBuf {
+		t.Fatalf("Main() output is %q, want %q", outBuf.String(), expectedBuf)
+	}
+	opts := searchOptions{}
+	opts.noid = true
+	opts.verbose = true
+	results, err := readPasswords(ctx.Database, opts)
+	if err != nil {
+		t.Fatalf("readPasswords() err = %q, want nil", err)
+	}
+	actualLength := len(results)
+	expectedLength := 1
+	if actualLength != expectedLength {
+		t.Fatalf("actualLength = %q, want %q", actualLength, expectedLength)
+	}
+	actualContains := ContainsString(results, fmt.Sprintf("machine: %s, service: %s, user: %s, password type: plain, password: %s, archived: true", expectedMachine, expectedService, expectedUser, expectedPassword))
+	expectedContains := true
+	if actualContains != expectedContains {
+		t.Fatalf("actualContains = %v, want %v", actualContains, expectedContains)
+	}
+}

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -2,6 +2,8 @@
 
 ## main
 
+- search / update: passwords can be now archived, search hides these by default without deleting the
+  password
 - drop compatibility with cpm < 7.5: update from old versions to 24.2 first
 
 ## 24.2

--- a/guide/src/usage.md
+++ b/guide/src/usage.md
@@ -67,6 +67,8 @@ The search term is already specified in this case:
 id:        1, machine: example.com, service: http, user: myuser, password type: plain, password: 7U1FvIzubR95Itg
 ```
 
+Archived passwords are not shown, unless `-v` or `--verbose` is used.
+
 ## TOTP support
 
 TOTP is one from of Two-Factor Authentication (2FA), currently used by many popular websites
@@ -169,3 +171,9 @@ Deleted 1 password
 ```
 
 Again, you can use `cpm search` to find the password ID.
+
+An alternative for deletion is to just mark the password as archived:
+
+```console
+cpm update -i ... -a 1
+```


### PR DESCRIPTION
Sometimes delete goes too far to hide a probably no longer interesting
password, but not deleting it causes noise in the search output.

The problem is that previously either a password was deleted or not,
leaving no middle ground.

Fix the problem by introducing a new, archived state. cpm update can set
this flag and cpm search ignores archived passwords by default.

Note that the archived flag can be unset later, and search also has a
verbose mode which still shows archived passwords.
