### PR TITLE
test: rework to avoid mocking totp.GenerateCode()

### DIFF
--- a/commands/context.go
+++ b/commands/context.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/mdp/qrterminal/v3"
-	"github.com/pquerna/otp/totp"
 	"github.com/sethvargo/go-password/password"
 )
 
@@ -28,9 +27,6 @@ var GeneratePassword = password.Generate
 
 // GenerateQrCode creates a QR Code and writes it out to io.Writer.
 var GenerateQrCode = qrterminal.Generate
-
-// GenerateTotpCode creates a TOTP token using the current time.
-var GenerateTotpCode = totp.GenerateCode
 
 // OpenDatabase opens the database before running a subcommand.
 var OpenDatabase = openDatabase

--- a/commands/read.go
+++ b/commands/read.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mdp/qrterminal/v3"
+	"github.com/pquerna/otp/totp"
 	"github.com/spf13/cobra"
 )
 
@@ -122,7 +123,7 @@ func readPasswords(db *sql.DB, opts searchOptions) ([]string, error) {
 					return nil, fmt.Errorf("parsePassword() failed: %s", err)
 				}
 
-				password, err = GenerateTotpCode(sharedSecret, time.Now())
+				password, err = totp.GenerateCode(sharedSecret, Now())
 				if err != nil {
 					return nil, fmt.Errorf("totp.GenerateCode() failed: %s", err)
 				}

--- a/commands/read_test.go
+++ b/commands/read_test.go
@@ -9,14 +9,9 @@ import (
 	"io"
 	"os"
 	"testing"
-	"time"
 
 	"rsc.io/qr"
 )
-
-func GenerateTotpCodeForTesting(secret string, t time.Time) (string, error) {
-	return "output-from-oathtool", nil
-}
 
 func TestSelect(t *testing.T) {
 	ctx := CreateContextForTesting(t)
@@ -90,7 +85,8 @@ func TestSelectTotpCode(t *testing.T) {
 	if actualRet != expectedRet {
 		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
 	}
-	expectedOutput := "machine: mymachine, service: myservice, user: myuser, password type: TOTP code, password: output-from-oathtool\n"
+	// TOTP code depends on the 2020 time produced by NowForTesting()
+	expectedOutput := "machine: mymachine, service: myservice, user: myuser, password type: TOTP code, password: 013567\n"
 	actualOutput := outBuf.String()
 	if actualOutput != expectedOutput {
 		t.Fatalf("actualOutput = %q, want %q", actualOutput, expectedOutput)

--- a/commands/root_test.go
+++ b/commands/root_test.go
@@ -36,10 +36,6 @@ func CreateContextForTesting(t *testing.T) Context {
 	GeneratePassword = GeneratePasswordForTesting
 	t.Cleanup(func() { GeneratePassword = oldGeneratePassword })
 
-	oldGenerateTotpCode := GenerateTotpCode
-	GenerateTotpCode = GenerateTotpCodeForTesting
-	t.Cleanup(func() { GenerateTotpCode = oldGenerateTotpCode })
-
 	oldNow := Now
 	Now = NowForTesting
 	t.Cleanup(func() { Now = oldNow })


### PR DESCRIPTION
Instead, use Now() (which is mocked during testing) as a replacement for
time.Now() in readPasswords(), then no need to mock totp.GenerateCode().
