### PR TITLE
export: take a filtering query, like search does

### DIFF
--- a/commands/export.go
+++ b/commands/export.go
@@ -24,7 +24,7 @@ type passwordRow struct {
 	Modified     string
 }
 
-func exportPasswords(db *sql.DB) ([]byte, error) {
+func exportPasswords(db *sql.DB, args []string) ([]byte, error) {
 	var results []passwordRow
 	rows, err := db.Query("select id, machine, service, user, password, type, archived, created, modified from passwords")
 	if err != nil {
@@ -37,6 +37,10 @@ func exportPasswords(db *sql.DB) ([]byte, error) {
 		err = rows.Scan(&row.ID, &row.Machine, &row.Service, &row.User, &row.Password, &row.PasswordType, &row.Archived, &row.Created, &row.Modified)
 		if err != nil {
 			return nil, fmt.Errorf("rows.Scan() failed: %s", err)
+		}
+
+		if len(args) > 0 && !matchesQuery(args[0], row.ID, row.Machine, row.Service, row.User, row.PasswordType) {
+			continue
 		}
 
 		results = append(results, row)
@@ -54,8 +58,9 @@ func newExportCommand(ctx *Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "export",
 		Short: "exports passwords as JSON",
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			j, err := exportPasswords(ctx.Database)
+			j, err := exportPasswords(ctx.Database, args)
 			if err != nil {
 				return fmt.Errorf("readPasswords() failed: %s", err)
 			}

--- a/commands/export_test.go
+++ b/commands/export_test.go
@@ -65,3 +65,38 @@ func TestExport(t *testing.T) {
 		t.Fatalf("password.Modified = %q, want %q", password.Modified, "")
 	}
 }
+
+func TestExportSearch(t *testing.T) {
+	ctx := CreateContextForTesting(t)
+	_, err := ctx.Database.Exec(`insert into passwords (machine, service, user, password, type) values('mymachine', 'myservice', 'myuser', 'mypassword', 'plain');`)
+	if err != nil {
+		t.Fatalf("createPassword() = %q, want nil", err)
+	}
+	_, err = ctx.Database.Exec(`insert into passwords (machine, service, user, password, type) values('othermachine', 'otherservice', 'otheruser', 'otherpassword', 'plain');`)
+	if err != nil {
+		t.Fatalf("createPassword() = %q, want nil", err)
+	}
+	os.Args = []string{"", "export", "othermachine"}
+	inBuf := new(bytes.Buffer)
+	outBuf := new(bytes.Buffer)
+
+	actualRet := Main(inBuf, outBuf)
+
+	expectedRet := 0
+	if actualRet != expectedRet {
+		t.Fatalf("Main() = %q, want %q", actualRet, expectedRet)
+	}
+	actualOutput := outBuf.String()
+	var passwords []passwordRow
+	err = json.NewDecoder(bytes.NewBufferString(actualOutput)).Decode(&passwords)
+	if err != nil {
+		t.Fatalf("json.Decode() = %q, want nil", err)
+	}
+	if len(passwords) != 1 {
+		t.Fatalf("passwords len = %q, want %q", len(passwords), 1)
+	}
+	password := passwords[0]
+	if password.Machine != "othermachine" {
+		t.Fatalf("password.Machine = %q, want %q", password.Machine, "othermachine")
+	}
+}

--- a/commands/read.go
+++ b/commands/read.go
@@ -44,6 +44,14 @@ func parsePassword(s string) (string, error) {
 	return secrets[0], nil
 }
 
+// matchesQuery decides if a password matches a free-form search query.
+func matchesQuery(query string, id int, machine string, service string, user string, passwordType PasswordType) bool {
+	// Allow simply matching a sub-string: e.g. search for a service type or a part of a machine
+	// without explicitly telling if the query is a service or a machine.
+	s := fmt.Sprintf("%d %s %s %s %s", id, machine, service, user, passwordType)
+	return strings.Contains(s, query)
+}
+
 type searchOptions struct {
 	wantedMachine string
 	wantedService string
@@ -103,14 +111,8 @@ func readPasswords(db *sql.DB, opts searchOptions) ([]string, error) {
 			continue
 		}
 
-		if len(opts.args) > 0 {
-			// Allow simply matching a sub-string: e.g. search for a service type or a part
-			// of a machine without explicitly telling if the query is a service or a
-			// machine.
-			s := fmt.Sprintf("%d %s %s %s %s", id, machine, service, user, passwordType)
-			if !strings.Contains(s, opts.args[0]) {
-				continue
-			}
+		if len(opts.args) > 0 && !matchesQuery(opts.args[0], id, machine, service, user, passwordType) {
+			continue
 		}
 
 		if passwordType == "totp" {

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## main
+
+- export: now takes an optional search query, the same way `search` does, to limit what is exported
+
 ## 26.2
 
 - new `export` command to write the password database as a JSON file


### PR DESCRIPTION
Arguing that search and export are really similar, just export has JSON
output and search has human-readable output.
